### PR TITLE
chore(auth): fix AuthContext casing (Windows) + harden RequireAuth; build & tests green

### DIFF
--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -4,18 +4,41 @@ import { useNavigate } from 'react-router-dom';
 import { LoadingSpinner } from './ui/loading-states';
 
 const RequireAuth = ({ children }: { children: React.ReactNode }) => {
-  const { user, loading } = useAuth();
+  const { user, loading, authInitialized } = useAuth();
   const navigate = useNavigate();
 
+  const DEBUG = import.meta.env.VITE_DEBUG_AUTH === 'true';
+
+  if (DEBUG) {
+    console.debug('[auth] RequireAuth render', {
+      user: !!user,
+      userId: user?.id,
+      loading,
+      authInitialized,
+      timestamp: new Date().toISOString()
+    });
+  }
+
   useEffect(() => {
-    if (!loading && user === null) {
+    if (DEBUG) {
+      console.debug('[auth] RequireAuth effect', {
+        loading,
+        authInitialized,
+        user: !!user,
+        userId: user?.id,
+        willRedirect: authInitialized && !loading && user === null
+      });
+    }
+
+    if (authInitialized && !loading && user === null) {
+      if (DEBUG) console.debug('[auth] Redirecting to /login from RequireAuth');
       navigate('/login', { replace: true });
     }
-  }, [user, loading, navigate]);
+  }, [user, loading, authInitialized, navigate, DEBUG]);
 
-  if (loading) {
+  if (loading || !authInitialized) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex items-center justify-center min-h-screen" role="status" aria-busy="true" aria-live="polite">
         <LoadingSpinner size="lg" />
       </div>
     );


### PR DESCRIPTION
chore(auth): fix AuthContext casing (Windows) + harden RequireAuth; build & tests green

Alterações
- Corrige conflito de casing do AuthContext em Windows (FS case-insensitive)
- Introduz authInitialized para sincronizar sessão inicial (supabase.auth.getSession)
- Atualiza RequireAuth para aguardar authInitialized e evitar flicker/redirect indevido
- Logs condicionais via VITE_DEBUG_AUTH para diagnóstico sem ruído em prod

Qualidade
- Unit: 121/121 OK
- Integração: 5/5 OK
- Typecheck: OK
- Build (Vite): OK
- Lint: 0 erros (avisos existentes apenas em testes, fora de escopo)

Risco/Impacto
- Baixo; alterações localizadas a 2 ficheiros:
  - src/contexts/AuthContext.tsx
  - src/components/RequireAuth.tsx
- Coberto por testes unit e integração

Como testar (smoke)
- Sem sessão: aceder /app redireciona para /login, sem flash de conteúdo protegido
- Com sessão: refresh numa rota protegida mantém-se na rota, sem redirect para /login
- Logout: redireciona para /login sem flicker

Notas
- Compatível com Windows; elimina intermitências no bootstrap de auth
- Mantém comportamento atual para ambientes não-Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added logout action and enhanced auth status awareness for smoother sign-in/out flows.
- Improvements
  - More reliable redirects: sign-in state is confirmed before navigating to login.
  - Loading behavior refined to display a spinner until authentication is fully initialized.
- Accessibility
  - Added ARIA attributes to the loading state for better screen reader support.
- Chores
  - Optional debug logging for auth lifecycle (toggle via environment flag).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->