### PR TITLE
Unit 04: auth security cleanup + onboarding scaffold

### DIFF
--- a/src/components/auth/LoginForm.test.tsx
+++ b/src/components/auth/LoginForm.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import LoginForm from './LoginForm';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    login: vi.fn(),
+    loading: false,
+    user: null,
+  })),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: vi.fn(() => vi.fn()),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+vi.mock('../../services/authProviders', () => ({
+  signInWithGoogle: vi.fn(),
+  signInWithApple: vi.fn(),
+  signInWithFacebook: vi.fn(),
+}));
+
+vi.mock('../../lib/utils', () => ({
+  showError: vi.fn(),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// ── Tests — OAuth desabilitados ──────────────────────────────────────────────
+
+describe('LoginForm — OAuth buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('botão Google deve estar desabilitado', () => {
+    render(<LoginForm />);
+    const btn = screen.getByRole('button', { name: /google/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('botão Google deve mostrar "Em breve"', () => {
+    render(<LoginForm />);
+    expect(screen.getByRole('button', { name: /google/i })).toHaveTextContent(/em breve/i);
+  });
+
+  it('botão Apple deve estar desabilitado', () => {
+    render(<LoginForm />);
+    const btn = screen.getByRole('button', { name: /apple/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('botão Apple deve mostrar "Em breve"', () => {
+    render(<LoginForm />);
+    expect(screen.getByRole('button', { name: /apple/i })).toHaveTextContent(/em breve/i);
+  });
+
+  it('botão Facebook deve estar desabilitado', () => {
+    render(<LoginForm />);
+    const btn = screen.getByRole('button', { name: /facebook/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('botão Facebook deve mostrar "Em breve"', () => {
+    render(<LoginForm />);
+    expect(screen.getByRole('button', { name: /facebook/i })).toHaveTextContent(/em breve/i);
+  });
+
+  it('clicar nos botões OAuth desabilitados não deve chamar signIn', async () => {
+    const user = userEvent.setup();
+    const { signInWithGoogle, signInWithApple, signInWithFacebook } =
+      await import('../../services/authProviders');
+
+    render(<LoginForm />);
+
+    // Buttons are disabled — clicks should not fire handlers
+    const googleBtn = screen.getByRole('button', { name: /google/i });
+    const appleBtn = screen.getByRole('button', { name: /apple/i });
+    const facebookBtn = screen.getByRole('button', { name: /facebook/i });
+
+    await user.click(googleBtn);
+    await user.click(appleBtn);
+    await user.click(facebookBtn);
+
+    expect(signInWithGoogle).not.toHaveBeenCalled();
+    expect(signInWithApple).not.toHaveBeenCalled();
+    expect(signInWithFacebook).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -136,25 +136,28 @@ export default function LoginForm() {
         </div>
 
         <div className="space-y-2">
-          <Button type="button" onClick={() => handleOAuth('google')} disabled={loading} variant="outline" className="w-full">
+          <Button type="button" disabled variant="outline" className="w-full relative">
             <div className="w-4 h-4 mr-2 bg-[#4285f4] rounded-sm flex items-center justify-center">
               <span className="text-white text-xs font-bold">G</span>
             </div>
             Entrar com Google
+            <span className="ml-2 text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">Em breve</span>
           </Button>
 
-          <Button type="button" onClick={() => handleOAuth('apple')} disabled={loading} variant="outline" className="w-full">
+          <Button type="button" disabled variant="outline" className="w-full relative">
             <div className="w-4 h-4 mr-2 bg-black rounded-sm flex items-center justify-center">
               <span className="text-white text-xs">🍎</span>
             </div>
             Entrar com Apple
+            <span className="ml-2 text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">Em breve</span>
           </Button>
 
-          <Button type="button" onClick={() => handleOAuth('facebook')} disabled={loading} variant="outline" className="w-full">
+          <Button type="button" disabled variant="outline" className="w-full relative">
             <div className="w-4 h-4 mr-2 bg-[#1877f2] rounded-sm flex items-center justify-center">
               <span className="text-white text-xs font-bold">f</span>
             </div>
             Entrar com Facebook
+            <span className="ml-2 text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">Em breve</span>
           </Button>
         </div>
       </div>

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AuthProvider, useAuth } from './AuthContext';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      signInWithPassword: vi.fn(),
+      signUp: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+      signOut: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../hooks/useUserDataInvalidation', () => ({
+  useUserDataInvalidation: vi.fn(),
+}));
+
+vi.mock('../shared/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Helper component ─────────────────────────────────────────────────────────
+
+function TestConsumer() {
+  const { loading, user } = useAuth();
+  const status = loading ? 'loading' : user ? 'authenticated' : 'unauthenticated';
+  return <div data-testid="status">{status}</div>;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('deve começar no estado loading=true', async () => {
+    const { supabase } = await import('../lib/supabaseClient');
+    // getSession never resolves — keeps us in loading state
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise(() => {})
+    );
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+  });
+
+  it('deve resolver para unauthenticated quando getSession retorna sessão nula', async () => {
+    const { supabase } = await import('../lib/supabaseClient');
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    // Flush all microtasks + timers so the resolved promise and state update settle
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(screen.getByTestId('status').textContent).toBe('unauthenticated');
+  });
+
+  it('fallback timer deve ter timeout >= 5000ms (esperado: 8000ms)', async () => {
+    const { supabase } = await import('../lib/supabaseClient');
+    const { logger } = await import('../shared/lib/logger');
+
+    // getSession blocks forever — only the fallback timer can resolve loading
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise(() => {})
+    );
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    // Deve ainda estar em loading ao avançar 4900ms
+    act(() => {
+      vi.advanceTimersByTime(4900);
+    });
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    // Ao atingir 8000ms totais, deve resolver (React flushed inside act)
+    await act(async () => {
+      vi.advanceTimersByTime(3100); // 4900 + 3100 = 8000
+    });
+
+    expect(screen.getByTestId('status').textContent).toBe('unauthenticated');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Timeout'),
+      expect.anything()
+    );
+  });
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -80,14 +80,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Inicializar autenticação
     initializeAuth();
     
-    // Fallback: garantir que loading seja false após 3 segundos
+    // Fallback: garantir que loading seja false após 8 segundos
+    // (decisão Unit 4: 3s era demasiado curto para rede móvel PT; 8s é razoável para dogfood)
     const fallbackTimer = setTimeout(() => {
       if (mounted && !initializationComplete) {
-        logger.warn('[Auth] Timeout na inicialização - forçando loading = false');
+        logger.warn('[Auth] Timeout na inicialização auth (8s) — possível problema de rede ou Supabase', {
+          timestamp: new Date().toISOString(),
+        });
         setLoading(false);
         initializationComplete = true;
       }
-    }, 3000);
+    }, 8000);
     
     return () => {
       mounted = false;

--- a/src/features/onboarding/EmptyState.test.tsx
+++ b/src/features/onboarding/EmptyState.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renderiza title e description', () => {
+    render(<EmptyState title="Sem dados" description="Ainda não há nada por aqui." />);
+    expect(screen.getByRole('heading', { name: /sem dados/i })).toBeInTheDocument();
+    expect(screen.getByText(/ainda não há nada por aqui/i)).toBeInTheDocument();
+  });
+
+  it('chama onCta ao clicar no botão CTA', async () => {
+    const user = userEvent.setup();
+    const handleCta = vi.fn();
+    render(
+      <EmptyState
+        title="Sem dados"
+        description="Descrição"
+        ctaLabel="Começar"
+        onCta={handleCta}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /começar/i }));
+    expect(handleCta).toHaveBeenCalledOnce();
+  });
+
+  it('não renderiza botão quando onCta está ausente', () => {
+    render(<EmptyState title="Sem dados" description="Descrição" ctaLabel="Começar" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renderiza o icon quando fornecido', () => {
+    render(
+      <EmptyState
+        title="Sem dados"
+        description="Descrição"
+        icon={<span data-testid="custom-icon">🌟</span>}
+      />
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+});

--- a/src/features/onboarding/EmptyState.tsx
+++ b/src/features/onboarding/EmptyState.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button } from '../../components/ui/button';
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  onCta?: () => void;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({ title, description, ctaLabel, onCta, icon, className }: EmptyStateProps) {
+  return (
+    <div className={`flex flex-col items-center justify-center gap-4 py-12 text-center ${className ?? ''}`}>
+      {icon && <div className="text-4xl text-muted-foreground">{icon}</div>}
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="text-sm text-muted-foreground max-w-sm">{description}</p>
+      {onCta && ctaLabel && (
+        <Button onClick={onCta}>{ctaLabel}</Button>
+      )}
+    </div>
+  );
+}

--- a/src/features/onboarding/OnboardingWizard.test.tsx
+++ b/src/features/onboarding/OnboardingWizard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { OnboardingWizard } from './OnboardingWizard';
+
+const defaultProps = {
+  currentStep: 1,
+  onNext: vi.fn(),
+  onSkip: vi.fn(),
+  onCreateAccount: vi.fn(),
+  onSeedCategories: vi.fn(),
+};
+
+describe('OnboardingWizard', () => {
+  it('renderiza conteúdo do passo 1 (criar conta)', () => {
+    render(<OnboardingWizard {...defaultProps} currentStep={1} />);
+    expect(screen.getByText(/criar conta/i)).toBeInTheDocument();
+  });
+
+  it('renderiza conteúdo do passo 2 (categorias)', () => {
+    render(<OnboardingWizard {...defaultProps} currentStep={2} />);
+    expect(screen.getByRole('heading', { name: /categori/i })).toBeInTheDocument();
+  });
+
+  it('renderiza conteúdo do passo 3 (explorar)', () => {
+    render(<OnboardingWizard {...defaultProps} currentStep={3} />);
+    expect(screen.getByText(/explor/i)).toBeInTheDocument();
+  });
+
+  it('botão Saltar chama onSkip', async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+    render(<OnboardingWizard {...defaultProps} onSkip={onSkip} />);
+    await user.click(screen.getByRole('button', { name: /saltar/i }));
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it('botão Próximo chama onNext nos passos 1 e 2', async () => {
+    const user = userEvent.setup();
+    const onNext = vi.fn();
+    render(<OnboardingWizard {...defaultProps} currentStep={1} onNext={onNext} />);
+    await user.click(screen.getByRole('button', { name: /próximo/i }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('botão Concluir aparece no passo 3', () => {
+    render(<OnboardingWizard {...defaultProps} currentStep={3} />);
+    expect(screen.getByRole('button', { name: /concluir/i })).toBeInTheDocument();
+  });
+});

--- a/src/features/onboarding/OnboardingWizard.tsx
+++ b/src/features/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../../components/ui/card';
+
+const TOTAL_STEPS = 3;
+
+interface OnboardingWizardProps {
+  currentStep: number;
+  onNext: () => void;
+  onSkip: () => void;
+  onCreateAccount: () => void;
+  onSeedCategories: () => void;
+}
+
+const STEPS = [
+  {
+    title: 'Criar conta',
+    description: 'Regista-te para guardar os teus dados de forma segura e aceder em qualquer dispositivo.',
+    cta: 'Criar conta',
+  },
+  {
+    title: 'Configurar categorias',
+    description: 'Personaliza as categorias de receitas e despesas para refletir a tua vida financeira.',
+    cta: 'Adicionar categorias',
+  },
+  {
+    title: 'Explorar a aplicação',
+    description: 'Descobre as funcionalidades disponíveis e começa a gerir as tuas finanças.',
+    cta: 'Explorar',
+  },
+];
+
+export function OnboardingWizard({
+  currentStep,
+  onNext,
+  onSkip,
+}: OnboardingWizardProps) {
+  const stepIndex = Math.max(0, Math.min(currentStep - 1, TOTAL_STEPS - 1));
+  const step = STEPS[stepIndex];
+  const isLastStep = currentStep >= TOTAL_STEPS;
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>{step.title}</CardTitle>
+        {/* Progress dots */}
+        <div className="flex gap-1.5 pt-2" aria-label={`Passo ${currentStep} de ${TOTAL_STEPS}`}>
+          {Array.from({ length: TOTAL_STEPS }, (_, i) => (
+            <span
+              key={i}
+              className={`h-2 w-2 rounded-full transition-colors ${
+                i < currentStep ? 'bg-primary' : 'bg-muted'
+              }`}
+            />
+          ))}
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{step.description}</p>
+      </CardContent>
+
+      <CardFooter className="flex justify-between gap-2">
+        <Button variant="ghost" onClick={onSkip}>
+          Saltar
+        </Button>
+        <Button onClick={onNext}>
+          {isLastStep ? 'Concluir' : 'Próximo'}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,4 @@
+export { useOnboardingState } from './useOnboardingState';
+export type { OnboardingState } from './useOnboardingState';
+export { EmptyState } from './EmptyState';
+export { OnboardingWizard } from './OnboardingWizard';

--- a/src/features/onboarding/useOnboardingState.test.ts
+++ b/src/features/onboarding/useOnboardingState.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useOnboardingState } from './useOnboardingState';
+
+const STORAGE_KEY = 'fff_onboarding_done';
+
+// setupTests.ts substitui localStorage por spies sem estado real.
+// Criamos um store em memória e ligamos as implementações.
+let store: Record<string, string> = {};
+
+const setupLocalStorageMock = () => {
+  store = {};
+  vi.mocked(localStorage.getItem).mockImplementation((key: string) => store[key] ?? null);
+  vi.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => { store[key] = value; });
+  vi.mocked(localStorage.removeItem).mockImplementation((key: string) => { delete store[key]; });
+  vi.mocked(localStorage.clear).mockImplementation(() => { store = {}; });
+};
+
+describe('useOnboardingState', () => {
+  beforeEach(() => {
+    setupLocalStorageMock();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('showWizard=true no primeiro login (sem flag no localStorage)', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    expect(result.current.showWizard).toBe(true);
+  });
+
+  it('showWizard=false se flag já existir no localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useOnboardingState());
+    expect(result.current.showWizard).toBe(false);
+  });
+
+  it('completeOnboarding persiste a flag e fecha o wizard', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    act(() => { result.current.completeOnboarding(); });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(result.current.showWizard).toBe(false);
+  });
+
+  it('skipOnboarding persiste a flag e fecha o wizard', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    act(() => { result.current.skipOnboarding(); });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(result.current.showWizard).toBe(false);
+  });
+
+  it('currentStep começa em 1', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    expect(result.current.currentStep).toBe(1);
+  });
+
+  it('nextStep avança o passo de 1 para 2', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    act(() => { result.current.nextStep(); });
+    expect(result.current.currentStep).toBe(2);
+  });
+
+  it('nextStep no último passo (3) chama completeOnboarding', () => {
+    const { result } = renderHook(() => useOnboardingState());
+    act(() => { result.current.nextStep(); }); // 1→2
+    act(() => { result.current.nextStep(); }); // 2→3
+    act(() => { result.current.nextStep(); }); // 3→complete
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(result.current.showWizard).toBe(false);
+  });
+});

--- a/src/features/onboarding/useOnboardingState.ts
+++ b/src/features/onboarding/useOnboardingState.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+const STORAGE_KEY = 'fff_onboarding_done';
+const TOTAL_STEPS = 3;
+
+export interface OnboardingState {
+  showWizard: boolean;
+  currentStep: number;
+  nextStep: () => void;
+  skipOnboarding: () => void;
+  completeOnboarding: () => void;
+}
+
+const isDone = (): boolean => {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const useOnboardingState = (): OnboardingState => {
+  const [showWizard, setShowWizard] = useState<boolean>(!isDone());
+  const [currentStep, setCurrentStep] = useState<number>(1);
+
+  const completeOnboarding = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // Storage unavailable — continue silently
+    }
+    setShowWizard(false);
+  };
+
+  const skipOnboarding = () => {
+    completeOnboarding();
+  };
+
+  const nextStep = () => {
+    if (currentStep >= TOTAL_STEPS) {
+      completeOnboarding();
+    } else {
+      setCurrentStep((s) => s + 1);
+    }
+  };
+
+  return { showWizard, currentStep, nextStep, skipOnboarding, completeOnboarding };
+};


### PR DESCRIPTION
## Summary

- **Task 5** — `AuthContext` fallback timer alargado de 3 s para 8 s para evitar falsos timeouts em rede móvel PT (dogfood); mensagem de warn melhorada com timestamp. Testes TDD com fake timers.
- **Task 6** — Botões OAuth (Google / Apple / Facebook) permanentemente `disabled` com badge visual *Em breve*; handlers removidos. Testes garantem que `signIn*` nunca é invocado.
- **Task 7** — Scaffold de onboarding: `useOnboardingState` (hook + localStorage via `fff_onboarding_done`), `EmptyState` (componente genérico), `OnboardingWizard` (3 passos com progress dots + Saltar/Próximo/Concluir), barrel `index.ts`. 17 novos testes TDD.

## Test coverage added

| Ficheiro | Testes |
|---|---|
| `src/contexts/AuthContext.test.tsx` | 3 |
| `src/components/auth/LoginForm.test.tsx` | 7 |
| `src/features/onboarding/useOnboardingState.test.ts` | 7 |
| `src/features/onboarding/EmptyState.test.tsx` | 4 |
| `src/features/onboarding/OnboardingWizard.test.tsx` | 6 |

**Total: 27 novos testes, todos a passar.**

## Test Plan

- [x] `npx vitest run src/contexts/AuthContext.test.tsx` → 3/3
- [x] `npx vitest run src/components/auth/LoginForm.test.tsx` → 7/7
- [x] `npx vitest run src/features/onboarding/` → 17/17
- [x] `npx tsc --noEmit` → sem erros
- [ ] Rever UI dos botões OAuth em staging

> **Nota:** 2 testes de payroll falham no worktree por ausência de `.env` (sem credenciais Supabase); passam em `main` e não têm relação com estas alterações.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth provider buttons (Google, Apple, Facebook) now display "coming soon" status and are disabled.
  * New onboarding wizard with multi-step flow, progress indicators, and skip/next navigation.
  * Onboarding progress is now tracked and persisted across sessions.

* **Bug Fixes**
  * Extended authentication timeout from 3 to 8 seconds with improved diagnostic logging for network issues.

* **Tests**
  * Added comprehensive test coverage for login, authentication, and onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->