### PR TITLE
feat(payroll): Unit 12a — Motor Fiscal (OT dual-scale, IRS autónomo, mileage cap, ajudas de custo)

### DIFF
--- a/src/features/payroll/components/PayrollLeavesManager.tsx
+++ b/src/features/payroll/components/PayrollLeavesManager.tsx
@@ -38,6 +38,8 @@ export function PayrollLeavesManager({ contractId }: PayrollLeavesManagerProps) 
     medical_certificate: false,
     notes: ''
   });
+  // Unit 12a: employer_days for sick leave (days employer pays before SS takes over)
+  const [employerDays, setEmployerDays] = useState(3);
   const correlationId = useRef(globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const log = withContext({ feature: 'payroll', component: 'PayrollLeavesManager', correlationId: correlationId.current });
 
@@ -142,7 +144,9 @@ export function PayrollLeavesManager({ contractId }: PayrollLeavesManagerProps) 
         contract_id: contractId,
         paid_days: formData.paid_days || Math.floor(totalDays * (leaveType?.defaultPaid || 100) / 100),
         unpaid_days: formData.unpaid_days || (totalDays - Math.floor(totalDays * (leaveType?.defaultPaid || 100) / 100)),
-        percentage_paid: formData.percentage_paid || leaveType?.defaultPaid || 100
+        percentage_paid: formData.percentage_paid || leaveType?.defaultPaid || 100,
+        // Unit 12a: days employer pays before SS (only meaningful for sick leave)
+        employer_days: formData.leave_type === 'sick' ? employerDays : undefined,
       };
 
       if (editingLeave) {
@@ -465,12 +469,30 @@ export function PayrollLeavesManager({ contractId }: PayrollLeavesManagerProps) 
                   <Checkbox
                     id="medical_certificate"
                     checked={formData.medical_certificate}
-                    onCheckedChange={(checked) => 
+                    onCheckedChange={(checked) =>
                       setFormData(prev => ({ ...prev, medical_certificate: checked as boolean }))
                     }
                   />
                   <Label htmlFor="medical_certificate">Requer atestado médico</Label>
                 </div>
+
+                {/* Unit 12a: employer_days for sick leave */}
+                {formData.leave_type === 'sick' && (
+                  <div className="space-y-1">
+                    <Label htmlFor="employer-days">Dias a cargo do empregador</Label>
+                    <Input
+                      id="employer-days"
+                      type="number"
+                      min="0"
+                      max="30"
+                      value={employerDays}
+                      onChange={e => setEmployerDays(parseInt(e.target.value, 10) || 0)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Default: 3 dias. A partir do dia {employerDays + 1}, a Segurança Social paga.
+                    </p>
+                  </div>
+                )}
                 <div className="space-y-2">
                   <Label htmlFor="notes">Observações</Label>
                   <Textarea

--- a/src/features/payroll/components/PayrollModule.tsx
+++ b/src/features/payroll/components/PayrollModule.tsx
@@ -28,6 +28,7 @@ import HistoryWrapper from './PayrollHistoryPage';
 
 const PayslipPreview = lazy(() => import('./PayslipPreview'));
 const PayslipHistory = lazy(() => import('./PayslipHistory'));
+const TravelAllowancesPage = lazy(() => import('../pages/TravelAllowancesPage'));
 
 // Toggle para permitir rotas de preview em ambientes de teste (Playwright) ou quando ativado via env
 const DEV_ROUTES = import.meta.env.DEV || import.meta.env.VITE_E2E === '1' || import.meta.env.VITE_ENABLE_PAYROLL_PREVIEW === '1';
@@ -111,6 +112,11 @@ function PayrollContent() {
         <Route path="periods" element={<PayrollPeriodsManager />} />
         <Route path="onboarding" element={<PayrollOnboardingWizard />} />
         <Route path="recibos" element={<RecibosPage />} />
+        <Route path="ajudas-custo" element={
+          <Suspense fallback={<LoadingSpinner size="lg" />}>
+            <TravelAllowancesPage />
+          </Suspense>
+        } />
       </Routes>
     </>
   );

--- a/src/features/payroll/components/PayrollNavigation.tsx
+++ b/src/features/payroll/components/PayrollNavigation.tsx
@@ -98,6 +98,13 @@ export function PayrollNavigation({ className }: PayrollNavigationProps) {
       isNew: true
     },
     {
+      path: '/app/payroll/ajudas-custo',
+      label: 'Ajudas Custo',
+      icon: Car,
+      description: 'Ajudas de custo e deslocações',
+      isNew: true
+    },
+    {
       path: '/personal/payroll/config',
       label: 'Configurações',
       icon: Settings,

--- a/src/features/payroll/components/PayrollVacationForm.tsx
+++ b/src/features/payroll/components/PayrollVacationForm.tsx
@@ -33,6 +33,8 @@ export function PayrollVacationForm({ vacation, year, contractId, existingVacati
     description: vacation?.description || ''
   });
   const [isApproved, setIsApproved] = useState(vacation?.is_approved || false);
+  // Unit 12a: affects_subsidy reduces vacation subsidy pro-rata
+  const [affectsSubsidy, setAffectsSubsidy] = useState<boolean>((vacation as any)?.affects_subsidy ?? false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const log = withContext({ feature: 'payroll', component: 'PayrollVacationForm', correlationId: correlationId.current });
 
@@ -142,7 +144,8 @@ export function PayrollVacationForm({ vacation, year, contractId, existingVacati
         ...formData,
         days_count: workingDays,
         year,
-        is_approved: isApproved
+        is_approved: isApproved,
+        affects_subsidy: affectsSubsidy,
       };
       
       log.debug('Vacation data to save', { fields: Object.keys(vacationData) });
@@ -251,7 +254,21 @@ export function PayrollVacationForm({ vacation, year, contractId, existingVacati
           Marcar como aprovado
         </Label>
       </div>
-      
+
+      {/* Unit 12a: affects_subsidy */}
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="affects-subsidy"
+          checked={affectsSubsidy}
+          onChange={e => setAffectsSubsidy(e.target.checked)}
+          className="h-4 w-4"
+        />
+        <Label htmlFor="affects-subsidy" className="text-sm font-normal">
+          Reduz subsídio de férias pro-rata
+        </Label>
+      </div>
+
       <div className="flex justify-end space-x-2 pt-4">
         <Button type="button" variant="outline" onClick={onCancel}>
           Cancelar

--- a/src/features/payroll/components/WeeklyTimesheetForm.tsx
+++ b/src/features/payroll/components/WeeklyTimesheetForm.tsx
@@ -17,7 +17,9 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActiveContract } from '../hooks/useActiveContract';
 import { formatCurrency } from '@/lib/utils';
-import { calculateHours, segmentEntry, calcHourly } from '../lib/calc';
+import { calculateHours, segmentEntry, calcHourly, calcOtScaled, buildOtDayEntries } from '../lib/calc';
+import { fetchTaxRates } from '../services/payrollAdvanced.service';
+import type { OtScaledResult } from '../types/payroll-advanced.types';
 import { formatDateLocal } from '@/lib/dateUtils';
 import { withContext, maskId } from '@/shared/lib/logger';
 import { TimesheetHeader } from './timesheet/TimesheetHeader';
@@ -115,6 +117,9 @@ export function WeeklyTimesheetForm({ initialWeekStart, contractId, onSave }: We
   const [timesheet, setTimesheet] = useState<WeeklyTimesheet>({ entries: [] });
   const [existingEntries, setExistingEntries] = useState<PayrollTimeEntry[]>([]);
   const [otPolicy, setOtPolicy] = useState<PayrollOTPolicy | null>(null);
+  // Unit 12a: OT YTD tracker
+  const [otStats, setOtStats] = useState<OtScaledResult | null>(null);
+  const [otAnnualLimit, setOtAnnualLimit] = useState(150);
 
   // Região aria-live e aviso inline de dias bloqueados
   const [ariaLiveMsg, setAriaLiveMsg] = useState('');
@@ -229,6 +234,32 @@ export function WeeklyTimesheetForm({ initialWeekStart, contractId, onSave }: We
     };
     loadOTPolicy();
   }, [selectedContractId]);
+
+  // Unit 12a: recompute OT tracker whenever entries or policy change
+  useEffect(() => {
+    if (!otPolicy?.use_legal_defaults) {
+      setOtStats(null);
+      return;
+    }
+    const entriesArray = timesheet.entries;
+    if (!entriesArray || entriesArray.length === 0) {
+      setOtStats(null);
+      return;
+    }
+    const thresholdMins = ((otPolicy as any).threshold_hours ?? 8) * 60;
+    fetchTaxRates(new Date().getFullYear()).then(taxRates => {
+      const otEntries = buildOtDayEntries(entriesArray, thresholdMins);
+      const baseMinuteCents = Math.round(
+        ((activeContract as any)?.base_salary_cents ?? 0) / (thresholdMins * 4.33)
+      );
+      const result = calcOtScaled(
+        otEntries, baseMinuteCents, (otPolicy as any).ot_hours_ytd ?? 0,
+        taxRates.otRates, taxRates.otLimits, true,
+      );
+      setOtStats(result);
+      setOtAnnualLimit(taxRates.otLimits.mpe_hours);
+    }).catch(() => {}); // fail silently if tax_tables not yet seeded
+  }, [timesheet.entries, otPolicy]);
 
   // Effect para carregar entradas quando semana ou contrato muda
   useEffect(() => {
@@ -1811,6 +1842,57 @@ export function WeeklyTimesheetForm({ initialWeekStart, contractId, onSave }: We
           </div>
         </CardContent>
       </Card>
+
+      {/* OT YTD Tracker Panel — Unit 12a */}
+      {otStats && (
+        <div className="mt-4 p-4 border rounded-lg space-y-3">
+          <h3 className="font-medium text-sm">OT — Tracker Anual</h3>
+
+          <div>
+            <div className="flex justify-between text-xs text-muted-foreground mb-1">
+              <span>Escala 1→2 (100h)</span>
+              <span>{Math.min(otStats.newYtdHours, 100).toFixed(1)}h / 100h</span>
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${otStats.newYtdHours >= 100 ? 'bg-destructive' : 'bg-primary'}`}
+                style={{ width: `${Math.min((otStats.newYtdHours / 100) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex justify-between text-xs text-muted-foreground mb-1">
+              <span>Limite anual ({otAnnualLimit}h)</span>
+              <span>{otStats.newYtdHours.toFixed(1)}h / {otAnnualLimit}h</span>
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  otStats.annualLimitExceeded ? 'bg-destructive'
+                  : otStats.annualLimitWarning  ? 'bg-amber-500'
+                  : 'bg-primary'
+                }`}
+                style={{ width: `${Math.min((otStats.newYtdHours / otAnnualLimit) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+
+          {otStats.dailyLimitWarning && (
+            <p className="text-xs text-amber-600">⚠️ OT diária excede 2h em alguns dias desta semana</p>
+          )}
+          {otStats.annualLimitWarning && !otStats.annualLimitExceeded && (
+            <p className="text-xs text-amber-600">⚠️ A aproximar-se do limite anual</p>
+          )}
+          {otStats.annualLimitExceeded && (
+            <p className="text-xs text-red-600 font-medium">🚨 Limite anual de horas extra excedido</p>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            Este mês: {otStats.otHoursThisMonth.toFixed(1)}h OT
+          </p>
+        </div>
+      )}
 
       {/* Summary & Actions */}
       <Card>

--- a/src/features/payroll/components/__tests__/TravelAllowancesPage.test.tsx
+++ b/src/features/payroll/components/__tests__/TravelAllowancesPage.test.tsx
@@ -1,0 +1,44 @@
+// src/features/payroll/components/__tests__/TravelAllowancesPage.test.tsx
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../../hooks/useActiveContract', () => ({
+  useActiveContract: () => ({ activeContract: { id: 'c1', name: 'Test' }, loading: false }),
+}));
+vi.mock('../../services/payrollAdvanced.service', () => ({
+  fetchTravelAllowances: vi.fn().mockResolvedValue([]),
+  saveTravelAllowance: vi.fn().mockResolvedValue({ id: 'new-id', operation_id: 'op-1' }),
+  deleteTravelAllowance: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('TravelAllowancesPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the page heading', async () => {
+    const { default: TravelAllowancesPage } = await import('../../pages/TravelAllowancesPage');
+    render(<TravelAllowancesPage />, { wrapper: makeWrapper() });
+    expect(screen.getByText(/ajudas de custo/i)).toBeInTheDocument();
+  });
+
+  it('renders the type selector', async () => {
+    const { default: TravelAllowancesPage } = await import('../../pages/TravelAllowancesPage');
+    render(<TravelAllowancesPage />, { wrapper: makeWrapper() });
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
+  });
+
+  it('renders a save button', async () => {
+    const { default: TravelAllowancesPage } = await import('../../pages/TravelAllowancesPage');
+    render(<TravelAllowancesPage />, { wrapper: makeWrapper() });
+    expect(screen.getByRole('button', { name: /guardar/i })).toBeInTheDocument();
+  });
+});

--- a/src/features/payroll/hooks/useAdvancedPayslipInputs.ts
+++ b/src/features/payroll/hooks/useAdvancedPayslipInputs.ts
@@ -1,0 +1,27 @@
+// src/features/payroll/hooks/useAdvancedPayslipInputs.ts
+/**
+ * Aggregates advanced payslip inputs (OT, mileage, allowances, leaves)
+ * and invalidates ['payslip-calculation', contractId, period] after any mutation.
+ *
+ * This hook is a thin coordinator — actual data fetching is done by the
+ * two-phase calculatePayslip orchestrator in payrollService.ts.
+ * Components that need to trigger a payslip recalculation should import this
+ * hook and call invalidatePayslip() after mutations.
+ */
+import { useQueryClient } from '@tanstack/react-query';
+import { useTravelAllowances } from './useTravelAllowances';
+
+export function useAdvancedPayslipInputs(contractId: string | null, period: string) {
+  const qc = useQueryClient();
+  const travelAllowances = useTravelAllowances(contractId, period);
+
+  /** Call after any mutation that should trigger payslip recalculation */
+  const invalidatePayslip = () => {
+    qc.invalidateQueries({ queryKey: ['payslip-calculation', contractId, period] });
+  };
+
+  return {
+    travelAllowances,
+    invalidatePayslip,
+  };
+}

--- a/src/features/payroll/hooks/useTravelAllowances.ts
+++ b/src/features/payroll/hooks/useTravelAllowances.ts
@@ -1,0 +1,43 @@
+// src/features/payroll/hooks/useTravelAllowances.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchTravelAllowances,
+  saveTravelAllowance,
+  deleteTravelAllowance,
+} from '../services/payrollAdvanced.service';
+import type { TravelAllowanceInput, TravelAllowanceRecord } from '../types/payroll-advanced.types';
+
+export function useTravelAllowances(contractId: string | null, period: string) {
+  const qc = useQueryClient();
+  const key = ['travel-allowances', contractId, period] as const;
+
+  const query = useQuery<TravelAllowanceRecord[], Error>({
+    queryKey: key,
+    queryFn: () => fetchTravelAllowances(contractId!, period),
+    enabled: !!contractId,
+    staleTime: 60_000,
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: key });
+    qc.invalidateQueries({ queryKey: ['payslip-calculation', contractId, period] });
+  };
+
+  const save = useMutation<TravelAllowanceRecord, Error, TravelAllowanceInput>({
+    mutationFn: saveTravelAllowance,
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation<void, Error, string>({
+    mutationFn: deleteTravelAllowance,
+    onSuccess: invalidate,
+  });
+
+  return {
+    allowances: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    save,
+    remove,
+  };
+}

--- a/src/features/payroll/lib/__tests__/calc-advanced.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-advanced.test.ts
@@ -141,6 +141,15 @@ describe('calcTravelAllowance', () => {
     expect(r.exemptCents).toBe(4000);
     expect(r.taxableExcessCents).toBe(0);
   });
+
+  it('viatura propria with km=0: returns zeros (no division by zero)', () => {
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_viatura_propria', km: 0, role: 'general', declaredCents: 0 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(0);
+    expect(r.taxableExcessCents).toBe(0);
+  });
 });
 
 // ── calcLeaveImpact ───────────────────────────────────────────────────────────
@@ -174,6 +183,13 @@ describe('calcLeaveImpact', () => {
     const leave: LeaveRecord = { leaveType: 'maternity', totalDays: 10, employerDays: 0, affectsSubsidy: false };
     const r = calcLeaveImpact([leave], GROSS_DAILY);
     expect(r.unpaidDeductionCents).toBe(10 * GROSS_DAILY);
+  });
+
+  it('paternity leave: deducts (employer gross reduction, SS pays)', () => {
+    const leave: LeaveRecord = { leaveType: 'paternity', totalDays: 10, employerDays: 0, affectsSubsidy: false };
+    const r = calcLeaveImpact([leave], GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(10 * GROSS_DAILY);
+    expect(r.components.some(c => c.sign === '-')).toBe(true);
   });
 
   it('vacation affecting subsidy: adds to subsidyAdjustmentCents', () => {

--- a/src/features/payroll/lib/__tests__/calc-advanced.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-advanced.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calcOtIrsWithholding,
+  calcMileageCap,
+  calcTravelAllowance,
+  calcLeaveImpact,
+  mergeComponents,
+} from '../calc';
+import type {
+  OtScaledResult,
+  TravelAllowanceCaps,
+  LeaveRecord,
+} from '../../types/payroll-advanced.types';
+
+// ── Test constants ────────────────────────────────────────────────────────────
+
+const CAPS: TravelAllowanceCaps = {
+  national_general_cents: 6589,
+  national_admin_cents:   7265,
+  foreign_general_cents:  15636,
+  foreign_admin_cents:    17542,
+  breakdown: { lunch: 0.25, dinner: 0.25, sleep: 0.50 },
+};
+
+const MILEAGE_CAP_CENTS = 40; // €0,40/km
+
+// ── calcOtIrsWithholding ──────────────────────────────────────────────────────
+
+describe('calcOtIrsWithholding', () => {
+  it('computes 50% of base IRS rate applied to OT pay', () => {
+    // OT pay = €100 (10000 cents), base IRS rate = 28% → OT IRS = 10000 × 0.28 × 0.50 = 1400
+    expect(calcOtIrsWithholding(10000, 0.28, 0.50)).toBe(1400);
+  });
+
+  it('returns 0 when OT pay is 0', () => {
+    expect(calcOtIrsWithholding(0, 0.28, 0.50)).toBe(0);
+  });
+
+  it('returns 0 when IRS rate is 0', () => {
+    expect(calcOtIrsWithholding(10000, 0, 0.50)).toBe(0);
+  });
+
+  it('rounds to nearest cent', () => {
+    // 1001 × 0.28 × 0.50 = 140.14 → rounds to 140
+    expect(calcOtIrsWithholding(1001, 0.28, 0.50)).toBe(140);
+  });
+});
+
+// ── calcMileageCap ────────────────────────────────────────────────────────────
+
+describe('calcMileageCap', () => {
+  it('returns all exempt when rate <= cap', () => {
+    const r = calcMileageCap([{ km: 100, rateCentsPerKm: 40 }], 40);
+    expect(r.exemptCents).toBe(4000);
+    expect(r.taxableCents).toBe(0);
+    expect(r.totalCents).toBe(4000);
+  });
+
+  it('splits when rate > cap', () => {
+    // rate = 50¢/km, cap = 40¢/km → 10¢ taxable per km
+    const r = calcMileageCap([{ km: 100, rateCentsPerKm: 50 }], 40);
+    expect(r.exemptCents).toBe(4000);
+    expect(r.taxableCents).toBe(1000);
+    expect(r.totalCents).toBe(5000);
+  });
+
+  it('aggregates multiple trips', () => {
+    const r = calcMileageCap([
+      { km: 50, rateCentsPerKm: 40 },
+      { km: 100, rateCentsPerKm: 50 },
+    ], 40);
+    expect(r.exemptCents).toBe(50 * 40 + 100 * 40);  // 2000 + 4000 = 6000
+    expect(r.taxableCents).toBe(100 * 10);             // 1000
+  });
+
+  it('returns zeros for empty trip list', () => {
+    const r = calcMileageCap([], 40);
+    expect(r.exemptCents).toBe(0);
+    expect(r.taxableCents).toBe(0);
+  });
+});
+
+// ── calcTravelAllowance ───────────────────────────────────────────────────────
+
+describe('calcTravelAllowance', () => {
+  it('national general: 2 days within cap → all exempt', () => {
+    // 2 × 6589 = 13178 cents declared = cap → all exempt
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_nacional', days: 2, role: 'general', declaredCents: 13178 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(13178);
+    expect(r.taxableExcessCents).toBe(0);
+  });
+
+  it('national general: declared > cap → excess is taxable', () => {
+    // Cap = 2 × 6589 = 13178; declared = 15000 → taxable = 1822
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_nacional', days: 2, role: 'general', declaredCents: 15000 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(13178);
+    expect(r.taxableExcessCents).toBe(15000 - 13178);
+  });
+
+  it('national admin: uses admin cap', () => {
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_nacional', days: 1, role: 'admin', declaredCents: 7265 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(7265);
+    expect(r.taxableExcessCents).toBe(0);
+  });
+
+  it('foreign general: uses foreign_general cap', () => {
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_estrangeiro', days: 1, role: 'general', declaredCents: 15636 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(15636);
+    expect(r.taxableExcessCents).toBe(0);
+  });
+
+  it('alojamento: uses sleep fraction of national_general cap', () => {
+    // national_general = 6589, sleep = 0.50 → cap = floor(6589 × 0.50) = 3294 (or round)
+    const capAloj = Math.round(CAPS.national_general_cents * CAPS.breakdown.sleep);
+    const r = calcTravelAllowance(
+      { type: 'alojamento', days: 1, role: 'general', declaredCents: capAloj },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(capAloj);
+    expect(r.taxableExcessCents).toBe(0);
+  });
+
+  it('viatura propria: delegates to calcMileageCap', () => {
+    // 100km at 40¢/km = 4000 cents → all exempt
+    const r = calcTravelAllowance(
+      { type: 'deslocacao_viatura_propria', km: 100, role: 'general', declaredCents: 4000 },
+      CAPS, MILEAGE_CAP_CENTS,
+    );
+    expect(r.exemptCents).toBe(4000);
+    expect(r.taxableExcessCents).toBe(0);
+  });
+});
+
+// ── calcLeaveImpact ───────────────────────────────────────────────────────────
+
+describe('calcLeaveImpact', () => {
+  const GROSS_DAILY = 5000; // €50/day
+
+  it('returns zero impact for empty leave list', () => {
+    const r = calcLeaveImpact([], GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(0);
+    expect(r.subsidyAdjustmentCents).toBe(0);
+    expect(r.components).toHaveLength(0);
+  });
+
+  it('sick leave: adds informational components (no deduction)', () => {
+    const leave: LeaveRecord = { leaveType: 'sick', totalDays: 5, employerDays: 3, affectsSubsidy: false };
+    const r = calcLeaveImpact([leave], GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(0); // sick leave: employer pays days 1–3, SS pays rest
+    expect(r.components.some(c => c.label.includes('empregador'))).toBe(true);
+    expect(r.components.some(c => c.label.includes('SS'))).toBe(true);
+  });
+
+  it('unpaid leave: deducts daily gross × days', () => {
+    const leave: LeaveRecord = { leaveType: 'unpaid', totalDays: 2, employerDays: 0, affectsSubsidy: false };
+    const r = calcLeaveImpact([leave], GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(2 * GROSS_DAILY);
+    expect(r.components.some(c => c.sign === '-')).toBe(true);
+  });
+
+  it('maternity leave: deducts (employer gross reduction, SS pays)', () => {
+    const leave: LeaveRecord = { leaveType: 'maternity', totalDays: 10, employerDays: 0, affectsSubsidy: false };
+    const r = calcLeaveImpact([leave], GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(10 * GROSS_DAILY);
+  });
+
+  it('vacation affecting subsidy: adds to subsidyAdjustmentCents', () => {
+    const leave: LeaveRecord = { leaveType: 'vacation', totalDays: 3, employerDays: 0, affectsSubsidy: true };
+    const r = calcLeaveImpact([leave], GROSS_DAILY);
+    expect(r.subsidyAdjustmentCents).toBe(3 * GROSS_DAILY);
+    expect(r.unpaidDeductionCents).toBe(0);
+  });
+});
+
+// ── mergeComponents ───────────────────────────────────────────────────────────
+
+describe('mergeComponents', () => {
+  const base = {
+    gross_cents: 100000,
+    irs_cents:   20000,
+    ss_cents:    11000,
+    meal_cents:  8800,
+    net_cents:   61000,
+    working_days: 22,
+    components: [{ label: 'Salário base', amount_cents: 100000, sign: '+' as const }],
+  };
+
+  const emptyOt: OtScaledResult = {
+    otPayCents: 0, otHoursThisMonth: 0, newYtdHours: 0,
+    nightBonusCents: 0, dailyLimitWarning: false,
+    annualLimitWarning: false, annualLimitExceeded: false,
+    components: [],
+  };
+
+  it('returns base unchanged when no extras', () => {
+    const r = mergeComponents(base, emptyOt, 0,
+      { exemptCents: 0, taxableCents: 0, totalCents: 0 }, [],
+      { unpaidDeductionCents: 0, subsidyAdjustmentCents: 0, components: [] });
+    expect(r.net_cents).toBe(base.net_cents);
+    expect(r.components).toHaveLength(base.components.length);
+  });
+
+  it('adds OT pay to net', () => {
+    const otResult: OtScaledResult = {
+      ...emptyOt,
+      otPayCents: 5000,
+      components: [{ label: 'OT E1 2026-01-06', amount_cents: 5000, sign: '+' }],
+    };
+    const r = mergeComponents(base, otResult, 0,
+      { exemptCents: 0, taxableCents: 0, totalCents: 0 }, [],
+      { unpaidDeductionCents: 0, subsidyAdjustmentCents: 0, components: [] });
+    expect(r.net_cents).toBe(base.net_cents + 5000);
+    expect(r.components.some(c => c.label === 'OT E1 2026-01-06')).toBe(true);
+  });
+
+  it('subtracts IRS OT withholding from net', () => {
+    const otResult: OtScaledResult = {
+      ...emptyOt,
+      otPayCents: 5000,
+      components: [{ label: 'OT E1 2026-01-06', amount_cents: 5000, sign: '+' }],
+    };
+    const r = mergeComponents(base, otResult, 700,
+      { exemptCents: 0, taxableCents: 0, totalCents: 0 }, [],
+      { unpaidDeductionCents: 0, subsidyAdjustmentCents: 0, components: [] });
+    expect(r.net_cents).toBe(base.net_cents + 5000 - 700);
+    expect(r.components.some(c => c.label === 'IRS s/ Horas Extra')).toBe(true);
+  });
+
+  it('does not mutate the base object', () => {
+    mergeComponents(base, emptyOt, 0,
+      { exemptCents: 0, taxableCents: 0, totalCents: 0 }, [],
+      { unpaidDeductionCents: 0, subsidyAdjustmentCents: 0, components: [] });
+    expect(base.net_cents).toBe(61000);
+  });
+});

--- a/src/features/payroll/lib/__tests__/calc-ot-entries.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-ot-entries.test.ts
@@ -28,6 +28,12 @@ describe('isWorkDuringNightHours', () => {
   it('detects early morning work (before 07:00)', () => {
     expect(isWorkDuringNightHours('06:00', '08:00', '22:00', '07:00')).toBe(true);
   });
+  it('detects evening-into-night work (starts before 22:00, ends after 22:00)', () => {
+    expect(isWorkDuringNightHours('20:00', '23:00', '22:00', '07:00')).toBe(true);
+  });
+  it('detects shift starting just before night window', () => {
+    expect(isWorkDuringNightHours('21:59', '22:01', '22:00', '07:00')).toBe(true);
+  });
 });
 
 describe('buildOtDayEntries', () => {
@@ -82,5 +88,8 @@ describe('buildOtDayEntries', () => {
     // Only one OtDayEntry for 2026-01-05
     const dayEntries = result.filter(e => e.date === '2026-01-05');
     expect(dayEntries.length).toBeLessThanOrEqual(1);
+    if (dayEntries.length === 1) {
+      expect(dayEntries[0].otMinutes).toBe(90); // 450+120=570 - 480 threshold = 90
+    }
   });
 });

--- a/src/features/payroll/lib/__tests__/calc-ot-entries.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-ot-entries.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { buildOtDayEntries, isWorkDuringNightHours } from '../calc';
+import type { OtDayEntry } from '../../types/payroll-advanced.types';
+
+// Helper to build a minimal PayrollTimeEntry-like object
+function entry(date: string, start: string, end: string, durationMin: number, plannedMin: number, isHoliday = false, isSunday = false) {
+  return {
+    date,
+    start_time: start,
+    end_time: end,
+    duration_minutes: durationMin,
+    planned_minutes: plannedMin,
+    is_holiday: isHoliday,
+    is_sunday: isSunday,
+  };
+}
+
+describe('isWorkDuringNightHours', () => {
+  it('detects night work starting before midnight', () => {
+    expect(isWorkDuringNightHours('22:30', '23:30', '22:00', '07:00')).toBe(true);
+  });
+  it('detects night work crossing midnight', () => {
+    expect(isWorkDuringNightHours('23:00', '01:00', '22:00', '07:00')).toBe(true);
+  });
+  it('returns false for pure daytime work', () => {
+    expect(isWorkDuringNightHours('09:00', '17:00', '22:00', '07:00')).toBe(false);
+  });
+  it('detects early morning work (before 07:00)', () => {
+    expect(isWorkDuringNightHours('06:00', '08:00', '22:00', '07:00')).toBe(true);
+  });
+});
+
+describe('buildOtDayEntries', () => {
+  it('returns empty array for empty entries', () => {
+    expect(buildOtDayEntries([], 480)).toEqual([]);
+  });
+
+  it('returns empty when no OT (duration = planned)', () => {
+    const result = buildOtDayEntries([
+      entry('2026-01-05', '09:00', '17:00', 480, 480),
+    ], 480);
+    expect(result).toHaveLength(0);
+  });
+
+  it('computes otMinutes for a single day with OT', () => {
+    const result = buildOtDayEntries([
+      entry('2026-01-05', '09:00', '18:00', 540, 480), // 60 min OT
+    ], 480);
+    expect(result).toHaveLength(1);
+    expect(result[0].otMinutes).toBe(60);
+    expect(result[0].date).toBe('2026-01-05');
+    expect(result[0].isRestDay).toBe(false);
+  });
+
+  it('marks public holiday as rest day', () => {
+    const result = buildOtDayEntries([
+      entry('2026-01-06', '09:00', '18:00', 540, 480, true),
+    ], 480);
+    expect(result[0].isRestDay).toBe(true);
+  });
+
+  it('marks Sunday as rest day', () => {
+    const result = buildOtDayEntries([
+      entry('2026-01-11', '09:00', '18:00', 540, 480, false, true),
+    ], 480);
+    expect(result[0].isRestDay).toBe(true);
+  });
+
+  it('computes nightMinutes for night OT', () => {
+    // Works 22:00-23:00 = 60 min OT, all night hours
+    const result = buildOtDayEntries([
+      entry('2026-01-05', '22:00', '23:00', 540, 480), // 60 min OT
+    ], 480);
+    expect(result[0].nightMinutes).toBeGreaterThan(0);
+  });
+
+  it('aggregates multiple entries for the same day', () => {
+    const result = buildOtDayEntries([
+      entry('2026-01-05', '09:00', '17:30', 450, 480), // 0 OT (short)
+      entry('2026-01-05', '17:30', '19:30', 120, 0),   // 120 min extra
+    ], 480);
+    // Only one OtDayEntry for 2026-01-05
+    const dayEntries = result.filter(e => e.date === '2026-01-05');
+    expect(dayEntries.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/features/payroll/lib/__tests__/calc-ot-scaled.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-ot-scaled.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { calcOtScaled } from '../calc';
+import type { OtDayEntry, OtRates, OtAnnualLimits } from '../../types/payroll-advanced.types';
+
+const RATES: OtRates = {
+  up_to_100h: { first_hour_pct: 0.25, next_hours_pct: 0.375, rest_day_pct: 0.50 },
+  above_100h: { first_hour_pct: 0.50, next_hours_pct: 0.75, rest_day_pct: 1.00 },
+  night_work_pct: 0.25,
+  night_start: '22:00',
+  night_end: '07:00',
+};
+
+const LIMITS: OtAnnualLimits = {
+  mpe_hours: 175,
+  others_hours: 150,
+  irct_max_hours: 200,
+  daily_max_hours: 2,
+};
+
+// Base hourly rate: €10/hour = 1000 cents/hour = ~16.67 cents/min
+const BASE_CENTS_PER_MIN = Math.round(1000 / 60); // 17
+
+function makeEntry(date: string, otMinutes: number, isRestDay = false, nightMinutes = 0): OtDayEntry {
+  return { date, otMinutes, isRestDay, nightMinutes };
+}
+
+describe('calcOtScaled', () => {
+  it('returns zero pay when no OT entries', () => {
+    const r = calcOtScaled([], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    expect(r.otPayCents).toBe(0);
+    expect(r.components).toHaveLength(0);
+    expect(r.annualLimitExceeded).toBe(false);
+  });
+
+  it('applies E1 first_hour_pct to first 60 min of OT on a regular day', () => {
+    const entry = makeEntry('2026-01-05', 60); // exactly 1 hour OT
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    // First hour: 60 min × 17 c/min × (1 + 0.25) = 60 × 17 × 1.25
+    const expected = Math.round(60 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.first_hour_pct));
+    expect(r.otPayCents).toBe(expected);
+    expect(r.components[0].label).toContain('E1');
+  });
+
+  it('applies E1 next_hours_pct for OT beyond first hour', () => {
+    const entry = makeEntry('2026-01-05', 90); // 1.5h OT
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    // First 60 min at 25%, next 30 min at 37.5%
+    const firstHour  = Math.round(60 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.first_hour_pct));
+    const nextMins   = Math.round(30 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.next_hours_pct));
+    expect(r.otPayCents).toBe(firstHour + nextMins);
+  });
+
+  it('applies E1 rest_day_pct on holidays', () => {
+    const entry = makeEntry('2026-01-01', 60, true); // holiday
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    const expected = Math.round(60 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.rest_day_pct));
+    expect(r.otPayCents).toBe(expected);
+  });
+
+  it('switches to E2 rates when ytdHours > 100', () => {
+    const entry = makeEntry('2026-07-01', 60);
+    // Already at 101h YTD before this month
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 101, RATES, LIMITS, true);
+    const expected = Math.round(60 * BASE_CENTS_PER_MIN * (1 + RATES.above_100h.first_hour_pct));
+    expect(r.otPayCents).toBe(expected);
+    expect(r.components[0].label).toContain('E2');
+  });
+
+  it('transitions mid-month: some hours E1, some E2', () => {
+    // YTD before = 99h, this month 2h → crosses 100h boundary
+    const entry1 = makeEntry('2026-06-01', 60); // goes from 99h to 100h → still E1
+    const entry2 = makeEntry('2026-06-02', 60); // goes from 100h to 101h → E2
+    const r = calcOtScaled([entry1, entry2], BASE_CENTS_PER_MIN, 99, RATES, LIMITS, true);
+    expect(r.components.some(c => c.label.includes('E1'))).toBe(true);
+    expect(r.components.some(c => c.label.includes('E2'))).toBe(true);
+  });
+
+  it('applies daily limit warning when OT exceeds 2h on any day', () => {
+    const entry = makeEntry('2026-01-05', 150); // 2.5h OT
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    expect(r.dailyLimitWarning).toBe(true);
+  });
+
+  it('does NOT set daily limit warning when OT is exactly 2h', () => {
+    const entry = makeEntry('2026-01-05', 120); // exactly 2h OT
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    expect(r.dailyLimitWarning).toBe(false);
+  });
+
+  it('sets annual limit warning within 10h of limit', () => {
+    // MPE limit = 175h. YTD = 168h, this month = 6h → 174h → within 10h → warning
+    const entries = Array.from({ length: 6 }, (_, i) =>
+      makeEntry(`2026-11-${String(i + 1).padStart(2, '0')}`, 60),
+    );
+    const r = calcOtScaled(entries, BASE_CENTS_PER_MIN, 168, RATES, LIMITS, true);
+    expect(r.annualLimitWarning).toBe(true);
+    expect(r.annualLimitExceeded).toBe(false);
+  });
+
+  it('sets annual limit exceeded when total >= limit', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      makeEntry(`2026-12-${String(i + 1).padStart(2, '0')}`, 60),
+    );
+    const r = calcOtScaled(entries, BASE_CENTS_PER_MIN, 170, RATES, LIMITS, true);
+    expect(r.annualLimitExceeded).toBe(true);
+  });
+
+  it('uses others_hours limit when isMPE = false', () => {
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      makeEntry(`2026-12-${String(i + 1).padStart(2, '0')}`, 60),
+    );
+    // 150h others limit. YTD = 147h → total 152h → exceeded
+    const r = calcOtScaled(entries, BASE_CENTS_PER_MIN, 147, RATES, LIMITS, false);
+    expect(r.annualLimitExceeded).toBe(true);
+  });
+
+  it('encodes E1 in component label for scale 1 hours', () => {
+    const entry = makeEntry('2026-01-05', 60);
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    expect(r.components.every(c => c.label.includes('E1'))).toBe(true);
+  });
+
+  it('encodes E2 in component label for scale 2 hours', () => {
+    const entry = makeEntry('2026-01-05', 60);
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 101, RATES, LIMITS, true);
+    expect(r.components.every(c => c.label.includes('E2'))).toBe(true);
+  });
+});

--- a/src/features/payroll/lib/__tests__/calc-ot-scaled.test.ts
+++ b/src/features/payroll/lib/__tests__/calc-ot-scaled.test.ts
@@ -125,4 +125,29 @@ describe('calcOtScaled', () => {
     const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 101, RATES, LIMITS, true);
     expect(r.components.every(c => c.label.includes('E2'))).toBe(true);
   });
+
+  it('correctly splits first-hour budget across E1/E2 boundary', () => {
+    // ytdHoursBefore = 99.5h → scaleBreakMinutes = 30
+    // otMinutes = 90: 30 min in E1, 60 min in E2
+    // E1: 30 min at first_hour_pct (30 of 60-min budget used)
+    // E2: 30 min at first_hour_pct (remaining budget), then 30 min at next_hours_pct
+    const entry = makeEntry('2026-06-15', 90);
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 99.5, RATES, LIMITS, true);
+    const e1Pay = Math.round(30 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.first_hour_pct));
+    const e2First = Math.round(30 * BASE_CENTS_PER_MIN * (1 + RATES.above_100h.first_hour_pct));
+    const e2Next  = Math.round(30 * BASE_CENTS_PER_MIN * (1 + RATES.above_100h.next_hours_pct));
+    expect(r.otPayCents).toBe(e1Pay + e2First + e2Next);
+    expect(r.components.some(c => c.label.includes('E1'))).toBe(true);
+    expect(r.components.some(c => c.label.includes('E2'))).toBe(true);
+  });
+
+  it('includes night bonus in otPayCents and emits Night Bonus component', () => {
+    const entry = makeEntry('2026-01-05', 60, false, 30); // 30 night minutes
+    const r = calcOtScaled([entry], BASE_CENTS_PER_MIN, 0, RATES, LIMITS, true);
+    const expectedOt = Math.round(60 * BASE_CENTS_PER_MIN * (1 + RATES.up_to_100h.first_hour_pct));
+    const expectedNight = Math.round(30 * BASE_CENTS_PER_MIN * RATES.night_work_pct);
+    expect(r.otPayCents).toBe(expectedOt + expectedNight);
+    expect(r.nightBonusCents).toBe(expectedNight);
+    expect(r.components.some(c => c.label.startsWith('Night Bonus'))).toBe(true);
+  });
 });

--- a/src/features/payroll/lib/calc.ts
+++ b/src/features/payroll/lib/calc.ts
@@ -1074,7 +1074,7 @@ export function buildOtDayEntries(
  * without extra state (e.g. label.includes('E2')).
  *
  * @param entries          OtDayEntry[] for the current payroll period
- * @param baseHourlyCents  Employee's base rate per MINUTE in cents
+ * @param baseMinuteCents  Employee's base rate per MINUTE in cents
  * @param ytdHoursBefore   YTD OT hours accumulated BEFORE this period
  * @param rates            OtRates from tax_tables
  * @param limits           OtAnnualLimits from tax_tables
@@ -1082,7 +1082,7 @@ export function buildOtDayEntries(
  */
 export function calcOtScaled(
   entries: OtDayEntry[],
-  baseHourlyCents: number,   // cents per MINUTE
+  baseMinuteCents: number,   // cents per MINUTE
   ytdHoursBefore: number,
   rates: OtRates,
   limits: OtAnnualLimits,
@@ -1119,10 +1119,10 @@ export function calcOtScaled(
       const e1Mins = Math.min(otMins, scaleBreakMinutes);
       const e2Mins = otMins - e1Mins;
       if (e1Mins > 0) {
-        e1Cents = Math.round(e1Mins * baseHourlyCents * (1 + rates.up_to_100h.rest_day_pct));
+        e1Cents = Math.round(e1Mins * baseMinuteCents * (1 + rates.up_to_100h.rest_day_pct));
       }
       if (e2Mins > 0) {
-        e2Cents = Math.round(e2Mins * baseHourlyCents * (1 + rates.above_100h.rest_day_pct));
+        e2Cents = Math.round(e2Mins * baseMinuteCents * (1 + rates.above_100h.rest_day_pct));
       }
     } else {
       // Regular day: first 60 min at first_hour_pct, remainder at next_hours_pct
@@ -1131,27 +1131,31 @@ export function calcOtScaled(
       if (e1TotalMins > 0) {
         const e1First = Math.min(e1TotalMins, 60);
         const e1Next  = e1TotalMins - e1First;
-        e1Cents += Math.round(e1First * baseHourlyCents * (1 + rates.up_to_100h.first_hour_pct));
+        e1Cents += Math.round(e1First * baseMinuteCents * (1 + rates.up_to_100h.first_hour_pct));
         if (e1Next > 0) {
-          e1Cents += Math.round(e1Next * baseHourlyCents * (1 + rates.up_to_100h.next_hours_pct));
+          e1Cents += Math.round(e1Next * baseMinuteCents * (1 + rates.up_to_100h.next_hours_pct));
         }
       }
-      // E2 portion (above 100h YTD)
+      // E2 portion — continue from where E1 left off in the first-hour budget
+      const firstHourBudgetLeft = Math.max(0, 60 - Math.min(e1TotalMins, 60));
       const e2TotalMins = otMins - e1TotalMins;
       if (e2TotalMins > 0) {
-        const e2First = Math.min(e2TotalMins, 60);
+        const e2First = Math.min(e2TotalMins, firstHourBudgetLeft);
         const e2Next  = e2TotalMins - e2First;
-        e2Cents += Math.round(e2First * baseHourlyCents * (1 + rates.above_100h.first_hour_pct));
+        if (e2First > 0) {
+          e2Cents += Math.round(e2First * baseMinuteCents * (1 + rates.above_100h.first_hour_pct));
+        }
         if (e2Next > 0) {
-          e2Cents += Math.round(e2Next * baseHourlyCents * (1 + rates.above_100h.next_hours_pct));
+          e2Cents += Math.round(e2Next * baseMinuteCents * (1 + rates.above_100h.next_hours_pct));
         }
       }
     }
 
     // Night bonus
     if (entry.nightMinutes > 0) {
-      const nightBonus = Math.round(entry.nightMinutes * baseHourlyCents * rates.night_work_pct);
+      const nightBonus = Math.round(entry.nightMinutes * baseMinuteCents * rates.night_work_pct);
       nightBonusCents += nightBonus;
+      components.push({ label: `Night Bonus ${entry.date}`, amount_cents: nightBonus, sign: '+' });
     }
 
     otPayCents += e1Cents + e2Cents;

--- a/src/features/payroll/lib/calc.ts
+++ b/src/features/payroll/lib/calc.ts
@@ -12,7 +12,8 @@ import {
   PlannedSchedule,
   PayrollCalculation
 } from '../types';
-import type { OtDayEntry, OtRates, OtAnnualLimits, OtScaledResult } from '../types/payroll-advanced.types';
+import type { OtDayEntry, OtRates, OtAnnualLimits, OtScaledResult, TravelAllowanceCaps, LeaveRecord, LeaveImpact } from '../types/payroll-advanced.types';
+import type { PayslipCalculation } from '../types/payroll-core.types';
 import { formatDateLocal } from '@/lib/dateUtils';
 import { logger } from '../../../shared/lib/logger';
 
@@ -1184,4 +1185,140 @@ export function calcOtScaled(
     annualLimitExceeded,
     components,
   };
+}
+
+// ── Unit 12a Task 5: Motor Fiscal PT — Pure Functions ─────────────────────────
+
+/**
+ * Calculates IRS withholding on overtime pay.
+ * Portuguese law: OT withholding = otPay × baseIrsRate × withholdingRateOfBase (typically 50%).
+ */
+export function calcOtIrsWithholding(
+  otPayCents: number,
+  baseIrsRateFraction: number,
+  withholdingRateOfBase: number,
+): number {
+  return Math.round(otPayCents * baseIrsRateFraction * withholdingRateOfBase);
+}
+
+/**
+ * Splits mileage reimbursement into AT-exempt and taxable portions.
+ * Amounts above the official cap per km are taxable.
+ */
+export function calcMileageCap(
+  trips: { km: number; rateCentsPerKm: number }[],
+  capCentsPerKm: number,
+): { exemptCents: number; taxableCents: number; totalCents: number } {
+  let exemptCents = 0;
+  let taxableCents = 0;
+  for (const trip of trips) {
+    exemptCents  += Math.round(trip.km * Math.min(trip.rateCentsPerKm, capCentsPerKm));
+    taxableCents += Math.round(trip.km * Math.max(0, trip.rateCentsPerKm - capCentsPerKm));
+  }
+  return { exemptCents, taxableCents, totalCents: exemptCents + taxableCents };
+}
+
+/**
+ * Calculates exempt vs. taxable portions of a travel allowance (ajudas de custo).
+ * Delegates viatura própria to calcMileageCap; uses cap table for all other types.
+ */
+export function calcTravelAllowance(
+  allowance: {
+    type: 'alojamento' | 'deslocacao_nacional' | 'deslocacao_estrangeiro' | 'deslocacao_viatura_propria';
+    days?: number;
+    km?: number;
+    role: 'general' | 'admin';
+    declaredCents: number;
+  },
+  caps: TravelAllowanceCaps,
+  mileageCapCentsPerKm: number,
+): { exemptCents: number; taxableExcessCents: number } {
+  if (allowance.type === 'deslocacao_viatura_propria') {
+    const km = allowance.km ?? 0;
+    const ratePerKm = km > 0 ? allowance.declaredCents / km : 0;
+    const r = calcMileageCap([{ km, rateCentsPerKm: ratePerKm }], mileageCapCentsPerKm);
+    return { exemptCents: r.exemptCents, taxableExcessCents: r.taxableCents };
+  }
+
+  const capMap: Record<string, number> = {
+    deslocacao_nacional_general:    caps.national_general_cents,
+    deslocacao_nacional_admin:      caps.national_admin_cents,
+    deslocacao_estrangeiro_general: caps.foreign_general_cents,
+    deslocacao_estrangeiro_admin:   caps.foreign_admin_cents,
+    alojamento_general: Math.round(caps.national_general_cents * caps.breakdown.sleep),
+    alojamento_admin:   Math.round(caps.national_admin_cents   * caps.breakdown.sleep),
+  };
+
+  const capDaily = capMap[`${allowance.type}_${allowance.role}`] ?? 0;
+  const maxExempt = (allowance.days ?? 1) * capDaily;
+  const exemptCents = Math.min(allowance.declaredCents, maxExempt);
+  return { exemptCents, taxableExcessCents: Math.max(0, allowance.declaredCents - exemptCents) };
+}
+
+/**
+ * Computes the payroll impact of leave records (sick, unpaid, maternity, vacation subsidy).
+ */
+export function calcLeaveImpact(
+  leaves: LeaveRecord[],
+  grossDailyCents: number,
+): LeaveImpact {
+  let unpaidDeductionCents = 0;
+  let subsidyAdjustmentCents = 0;
+  const components: { label: string; amount_cents: number; sign: '+' | '-' }[] = [];
+
+  for (const leave of leaves) {
+    if (leave.leaveType === 'sick') {
+      const employerDays = Math.min(leave.totalDays, leave.employerDays);
+      if (employerDays > 0) {
+        components.push({ label: `Baixa (empregador, ${employerDays}d)`, amount_cents: 0, sign: '+' });
+      }
+      if (leave.totalDays > leave.employerDays) {
+        components.push({ label: `Baixa (SS, ${leave.totalDays - leave.employerDays}d)`, amount_cents: 0, sign: '+' });
+      }
+    } else if (leave.leaveType === 'unpaid') {
+      const d = leave.totalDays * grossDailyCents;
+      unpaidDeductionCents += d;
+      components.push({ label: `Licença não remunerada (${leave.totalDays}d)`, amount_cents: d, sign: '-' });
+    } else if (leave.leaveType === 'maternity' || leave.leaveType === 'paternity') {
+      const d = leave.totalDays * grossDailyCents;
+      unpaidDeductionCents += d;
+      components.push({ label: `Licença parental (SS, ${leave.totalDays}d)`, amount_cents: d, sign: '-' });
+    } else if (leave.leaveType === 'vacation' && leave.affectsSubsidy) {
+      const d = leave.totalDays * grossDailyCents;
+      subsidyAdjustmentCents += d;
+      components.push({ label: `Subsídio férias pro-rata (${leave.totalDays}d)`, amount_cents: d, sign: '-' });
+    }
+  }
+
+  return { unpaidDeductionCents, subsidyAdjustmentCents, components };
+}
+
+/**
+ * Merges OT, mileage, travel allowance, and leave components into a base PayslipCalculation.
+ * Returns a new object — does NOT mutate base.
+ */
+export function mergeComponents(
+  base: PayslipCalculation,
+  otResult: OtScaledResult,
+  otIrsCents: number,
+  mileage: { exemptCents: number; taxableCents: number; totalCents: number },
+  allowances: { exemptCents: number; taxableExcessCents: number }[],
+  leaveImpact: LeaveImpact,
+): PayslipCalculation {
+  const extra: { label: string; amount_cents: number; sign: '+' | '-' }[] = [
+    ...otResult.components,
+    ...(otIrsCents > 0 ? [{ label: 'IRS s/ Horas Extra', amount_cents: otIrsCents, sign: '-' as const }] : []),
+    ...(mileage.exemptCents > 0 ? [{ label: 'Quilometragem (isento)', amount_cents: mileage.exemptCents, sign: '+' as const }] : []),
+    ...(mileage.taxableCents > 0 ? [{ label: 'Quilometragem (tributável)', amount_cents: mileage.taxableCents, sign: '+' as const }] : []),
+    ...allowances.flatMap(a => [
+      ...(a.exemptCents > 0 ? [{ label: 'Ajudas Custo (isento)', amount_cents: a.exemptCents, sign: '+' as const }] : []),
+      ...(a.taxableExcessCents > 0 ? [{ label: 'Ajudas Custo (tributável)', amount_cents: a.taxableExcessCents, sign: '+' as const }] : []),
+    ]),
+    ...leaveImpact.components,
+  ];
+  const netDelta = extra.reduce(
+    (acc, c) => acc + (c.sign === '+' ? c.amount_cents : -c.amount_cents),
+    0,
+  );
+  return { ...base, components: [...base.components, ...extra], net_cents: base.net_cents + netDelta };
 }

--- a/src/features/payroll/lib/calc.ts
+++ b/src/features/payroll/lib/calc.ts
@@ -1,17 +1,18 @@
 // Serviço de cálculo de folha de pagamento
 // Funções puras para cálculos de horários, horas extras, subsídios e quilometragem
 
-import { 
-  PayrollContract, 
-  PayrollOTPolicy, 
-  PayrollHoliday, 
-  PayrollTimeEntry, 
+import {
+  PayrollContract,
+  PayrollOTPolicy,
+  PayrollHoliday,
+  PayrollTimeEntry,
   PayrollMileageTrip,
   PayrollVacation,
-  TimeSegment, 
-  PlannedSchedule, 
-  PayrollCalculation 
+  TimeSegment,
+  PlannedSchedule,
+  PayrollCalculation
 } from '../types';
+import type { OtDayEntry } from '../types/payroll-advanced.types';
 import { formatDateLocal } from '@/lib/dateUtils';
 import { logger } from '../../../shared/lib/logger';
 
@@ -23,34 +24,34 @@ import { logger } from '../../../shared/lib/logger';
  * @param nightEnd Fim do período noturno (ex: '07:00')
  * @returns true se alguma parte do trabalho ocorre durante período noturno
  */
-function isWorkDuringNightHours(
-  startTime: Date,
-  endTime: Date,
+/**
+ * Verifica se o trabalho ocorre durante horário noturno.
+ * Aceita horários no formato "HH:MM".
+ */
+export function isWorkDuringNightHours(
+  startTime: string,
+  endTime: string,
   nightStart: string,
   nightEnd: string
 ): boolean {
-  const startHour = startTime.getHours();
-  const startMinute = startTime.getMinutes();
-  const endHour = endTime.getHours();
-  const endMinute = endTime.getMinutes();
-  
+  const [startHour, startMinute] = startTime.split(':').map(Number);
+  const [endHour, endMinute] = endTime.split(':').map(Number);
   const [nightStartHour, nightStartMinute] = nightStart.split(':').map(Number);
   const [nightEndHour, nightEndMinute] = nightEnd.split(':').map(Number);
-  
+
   const workStartMinutes = startHour * 60 + startMinute;
   const workEndMinutes = endHour * 60 + endMinute;
   const nightStartMinutes = nightStartHour * 60 + nightStartMinute;
   const nightEndMinutes = nightEndHour * 60 + nightEndMinute;
-  
+
   // Se o período noturno atravessa meia-noite (ex: 22:00-07:00)
   if (nightStartMinutes > nightEndMinutes) {
-    // Trabalho noturno se:
-    // - Começa depois das 22h OU
-    // - Termina antes das 7h OU
-    // - Atravessa meia-noite
-    return workStartMinutes >= nightStartMinutes || 
-           workEndMinutes <= nightEndMinutes ||
-           workEndMinutes < workStartMinutes; // Atravessa meia-noite
+    // Night zone is [nightStart, midnight) ∪ [midnight, nightEnd)
+    // Shift overlaps if it starts in the late-night zone OR ends/starts in the early-morning zone OR crosses midnight
+    return workStartMinutes >= nightStartMinutes || // starts after 22:00
+           workEndMinutes <= nightEndMinutes ||      // ends before or at 07:00
+           workStartMinutes < nightEndMinutes ||     // starts before 07:00 (early morning)
+           workEndMinutes < workStartMinutes;        // crosses midnight
   } else {
     // Período noturno não atravessa meia-noite
     return (workStartMinutes >= nightStartMinutes && workStartMinutes < nightEndMinutes) ||
@@ -121,7 +122,8 @@ export function segmentEntry(
   // Verificar se é trabalho noturno (22h-7h conforme legislação portuguesa)
   const nightStart = otPolicy?.night_start_time || '22:00';
   const nightEnd = otPolicy?.night_end_time || '07:00';
-  const isNightShift = isWorkDuringNightHours(startTime, endTime, nightStart, nightEnd);
+  const toHHMM = (d: Date) => `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  const isNightShift = isWorkDuringNightHours(toHHMM(startTime), toHHMM(endTime), nightStart, nightEnd);
 
   const segments: TimeSegment[] = [];
 
@@ -146,7 +148,7 @@ export function segmentEntry(
       end: regularEndTime,
       isOvertime: false,
       hours: regularHours,
-      isNightShift: isWorkDuringNightHours(startTime, regularEndTime, nightStart, nightEnd)
+      isNightShift: isWorkDuringNightHours(toHHMM(startTime), toHHMM(regularEndTime), nightStart, nightEnd)
     });
 
     // Segmento de horas extras
@@ -155,7 +157,7 @@ export function segmentEntry(
       end: endTime,
       isOvertime: true,
       hours: overtimeHours,
-      isNightShift: isWorkDuringNightHours(regularEndTime, endTime, nightStart, nightEnd)
+      isNightShift: isWorkDuringNightHours(toHHMM(regularEndTime), toHHMM(endTime), nightStart, nightEnd)
     });
   }
 
@@ -998,4 +1000,60 @@ export function validateDeductions(
     isValid: errors.length === 0,
     errors
   };
+}
+
+// ── Unit 12a: OT Day Entry Builder ────────────────────────────────────────────
+
+/**
+ * Converts an array of PayrollTimeEntry records into OtDayEntry objects.
+ * Only returns entries where actual OT (duration > thresholdMinutes) occurred.
+ *
+ * @param entries Raw time entries for the period
+ * @param thresholdMinutes Daily threshold after which OT starts (e.g. 480 for 8h)
+ */
+export function buildOtDayEntries(
+  entries: Array<{
+    date: string;
+    start_time?: string | null;
+    end_time?: string | null;
+    duration_minutes: number;
+    planned_minutes?: number | null;
+    is_holiday?: boolean | null;
+    is_sunday?: boolean | null;
+  }>,
+  thresholdMinutes: number,
+): OtDayEntry[] {
+  // Group entries by date
+  const byDate = new Map<string, typeof entries>();
+  for (const e of entries) {
+    const list = byDate.get(e.date) ?? [];
+    list.push(e);
+    byDate.set(e.date, list);
+  }
+
+  const result: OtDayEntry[] = [];
+
+  for (const [date, dayEntries] of byDate) {
+    const totalMinutes = dayEntries.reduce((s, e) => s + (e.duration_minutes ?? 0), 0);
+    const otMinutes = Math.max(0, totalMinutes - thresholdMinutes);
+    if (otMinutes === 0) continue;
+
+    const isRestDay = dayEntries.some(e => e.is_holiday || e.is_sunday);
+
+    // Estimate night OT minutes: check if any entry overlaps with night hours
+    let nightMinutes = 0;
+    for (const e of dayEntries) {
+      if (!e.start_time || !e.end_time) continue;
+      if (isWorkDuringNightHours(e.start_time, e.end_time, '22:00', '07:00')) {
+        // Rough estimate: assume all OT from this entry is during night hours
+        // A more precise calculation would require minute-by-minute overlap
+        nightMinutes += Math.min(otMinutes, e.duration_minutes ?? 0);
+      }
+    }
+    nightMinutes = Math.min(nightMinutes, otMinutes);
+
+    result.push({ date, otMinutes, isRestDay, nightMinutes });
+  }
+
+  return result;
 }

--- a/src/features/payroll/lib/calc.ts
+++ b/src/features/payroll/lib/calc.ts
@@ -12,7 +12,7 @@ import {
   PlannedSchedule,
   PayrollCalculation
 } from '../types';
-import type { OtDayEntry } from '../types/payroll-advanced.types';
+import type { OtDayEntry, OtRates, OtAnnualLimits, OtScaledResult } from '../types/payroll-advanced.types';
 import { formatDateLocal } from '@/lib/dateUtils';
 import { logger } from '../../../shared/lib/logger';
 
@@ -1059,4 +1059,125 @@ export function buildOtDayEntries(
   }
 
   return result;
+}
+
+// ── Unit 12a: calcOtScaled ────────────────────────────────────────────────────
+
+/**
+ * Calculates scaled OT pay (Lei 13/2023 — duas escalas).
+ *
+ * Scale transition at 100 YTD hours:
+ *   - Escala 1 (E1): hours 0–100 → lower rates
+ *   - Escala 2 (E2): hours above 100 → higher rates
+ *
+ * Component labels encode 'E1' or 'E2' so callers can detect the scale
+ * without extra state (e.g. label.includes('E2')).
+ *
+ * @param entries          OtDayEntry[] for the current payroll period
+ * @param baseHourlyCents  Employee's base rate per MINUTE in cents
+ * @param ytdHoursBefore   YTD OT hours accumulated BEFORE this period
+ * @param rates            OtRates from tax_tables
+ * @param limits           OtAnnualLimits from tax_tables
+ * @param isMPE            True if company is MPE (micro/small) — uses 175h limit
+ */
+export function calcOtScaled(
+  entries: OtDayEntry[],
+  baseHourlyCents: number,   // cents per MINUTE
+  ytdHoursBefore: number,
+  rates: OtRates,
+  limits: OtAnnualLimits,
+  isMPE: boolean,
+): OtScaledResult {
+  const annualLimit = isMPE ? limits.mpe_hours : limits.others_hours;
+  let ytdHours = ytdHoursBefore;
+  let otPayCents = 0;
+  let nightBonusCents = 0;
+  let otHoursThisMonth = 0;
+  let dailyLimitWarning = false;
+
+  const components: OtScaledResult['components'] = [];
+
+  for (const entry of entries) {
+    const otMins = entry.otMinutes;
+    if (otMins <= 0) continue;
+
+    const otHours = otMins / 60;
+    otHoursThisMonth += otHours;
+
+    // Check daily limit (max 2h OT per day)
+    if (otMins > limits.daily_max_hours * 60) {
+      dailyLimitWarning = true;
+    }
+
+    // How many minutes remain in E1 (before 100h threshold)?
+    const scaleBreakMinutes = Math.max(0, (100 - ytdHours) * 60);
+
+    let e1Cents = 0;
+    let e2Cents = 0;
+
+    if (entry.isRestDay) {
+      const e1Mins = Math.min(otMins, scaleBreakMinutes);
+      const e2Mins = otMins - e1Mins;
+      if (e1Mins > 0) {
+        e1Cents = Math.round(e1Mins * baseHourlyCents * (1 + rates.up_to_100h.rest_day_pct));
+      }
+      if (e2Mins > 0) {
+        e2Cents = Math.round(e2Mins * baseHourlyCents * (1 + rates.above_100h.rest_day_pct));
+      }
+    } else {
+      // Regular day: first 60 min at first_hour_pct, remainder at next_hours_pct
+      // E1 portion (up to scaleBreakMinutes minutes)
+      const e1TotalMins = Math.min(otMins, scaleBreakMinutes);
+      if (e1TotalMins > 0) {
+        const e1First = Math.min(e1TotalMins, 60);
+        const e1Next  = e1TotalMins - e1First;
+        e1Cents += Math.round(e1First * baseHourlyCents * (1 + rates.up_to_100h.first_hour_pct));
+        if (e1Next > 0) {
+          e1Cents += Math.round(e1Next * baseHourlyCents * (1 + rates.up_to_100h.next_hours_pct));
+        }
+      }
+      // E2 portion (above 100h YTD)
+      const e2TotalMins = otMins - e1TotalMins;
+      if (e2TotalMins > 0) {
+        const e2First = Math.min(e2TotalMins, 60);
+        const e2Next  = e2TotalMins - e2First;
+        e2Cents += Math.round(e2First * baseHourlyCents * (1 + rates.above_100h.first_hour_pct));
+        if (e2Next > 0) {
+          e2Cents += Math.round(e2Next * baseHourlyCents * (1 + rates.above_100h.next_hours_pct));
+        }
+      }
+    }
+
+    // Night bonus
+    if (entry.nightMinutes > 0) {
+      const nightBonus = Math.round(entry.nightMinutes * baseHourlyCents * rates.night_work_pct);
+      nightBonusCents += nightBonus;
+    }
+
+    otPayCents += e1Cents + e2Cents;
+
+    if (e1Cents > 0) {
+      components.push({ label: `OT E1 ${entry.date}`, amount_cents: e1Cents, sign: '+' });
+    }
+    if (e2Cents > 0) {
+      components.push({ label: `OT E2 ${entry.date}`, amount_cents: e2Cents, sign: '+' });
+    }
+
+    ytdHours += otHours;
+  }
+
+  const newYtdHours = ytdHoursBefore + otHoursThisMonth;
+  const annualLimitExceeded = newYtdHours >= annualLimit;
+  const annualLimitWarning  = !annualLimitExceeded && (newYtdHours >= annualLimit - 10);
+
+  return {
+    otPayCents: otPayCents + nightBonusCents,
+    otHoursThisMonth,
+    newYtdHours,
+    nightBonusCents,
+    dailyLimitWarning,
+    annualLimitWarning,
+    annualLimitExceeded,
+    components,
+  };
 }

--- a/src/features/payroll/lib/calc.ts
+++ b/src/features/payroll/lib/calc.ts
@@ -48,10 +48,13 @@ export function isWorkDuringNightHours(
   if (nightStartMinutes > nightEndMinutes) {
     // Night zone is [nightStart, midnight) ∪ [midnight, nightEnd)
     // Shift overlaps if it starts in the late-night zone OR ends/starts in the early-morning zone OR crosses midnight
-    return workStartMinutes >= nightStartMinutes || // starts after 22:00
-           workEndMinutes <= nightEndMinutes ||      // ends before or at 07:00
-           workStartMinutes < nightEndMinutes ||     // starts before 07:00 (early morning)
-           workEndMinutes < workStartMinutes;        // crosses midnight
+    return (
+      workStartMinutes >= nightStartMinutes ||  // starts at or after 22:00
+      workEndMinutes <= nightEndMinutes ||       // ends before or at 07:00
+      workStartMinutes < nightEndMinutes ||      // starts before 07:00
+      workEndMinutes < workStartMinutes ||       // crosses midnight
+      workEndMinutes > nightStartMinutes         // ends after 22:00 (same-day entry into night)
+    );
   } else {
     // Período noturno não atravessa meia-noite
     return (workStartMinutes >= nightStartMinutes && workStartMinutes < nightEndMinutes) ||
@@ -1040,17 +1043,17 @@ export function buildOtDayEntries(
 
     const isRestDay = dayEntries.some(e => e.is_holiday || e.is_sunday);
 
-    // Estimate night OT minutes: check if any entry overlaps with night hours
+    // Estimate night OT minutes: use proportional OT per entry
     let nightMinutes = 0;
     for (const e of dayEntries) {
       if (!e.start_time || !e.end_time) continue;
       if (isWorkDuringNightHours(e.start_time, e.end_time, '22:00', '07:00')) {
-        // Rough estimate: assume all OT from this entry is during night hours
-        // A more precise calculation would require minute-by-minute overlap
-        nightMinutes += Math.min(otMinutes, e.duration_minutes ?? 0);
+        // Proportion of this entry's duration relative to day total, applied to OT
+        const entryOtFraction = totalMinutes > 0 ? (e.duration_minutes ?? 0) / totalMinutes : 0;
+        nightMinutes += Math.round(otMinutes * entryOtFraction);
       }
     }
-    nightMinutes = Math.min(nightMinutes, otMinutes);
+    nightMinutes = Math.min(nightMinutes, otMinutes); // never exceed total OT
 
     result.push({ date, otMinutes, isRestDay, nightMinutes });
   }

--- a/src/features/payroll/pages/PayrollMileagePage.tsx
+++ b/src/features/payroll/pages/PayrollMileagePage.tsx
@@ -12,7 +12,9 @@ import { Plus, Edit, Trash2, Download, MapPin, TrendingUp, Euro, Search, Calenda
 import { format } from 'date-fns';
 import { pt } from 'date-fns/locale';
 import { formatCurrency } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 import { payrollService } from '../services/payrollService';
+import { calcMileageCap } from '../lib/calc';
 
 import { useActiveContract } from '../hooks/useActiveContract';
 import { MileageTripForm } from '../components/MileageTripForm';
@@ -427,7 +429,8 @@ const PayrollMileagePage: React.FC = () => {
                   </Button>
                 </div>
               ) : (
-                <div className="space-y-4">
+                <>
+                <div className="space-y-4" data-testid="trips-list">
                   {filteredTrips.map((trip) => (
                     <div key={trip.id} className="flex items-center justify-between p-4 border rounded-lg">
                       <div className="flex-1">
@@ -439,6 +442,24 @@ const PayrollMileagePage: React.FC = () => {
                           const amountCents = policy ? trip.km * policy.rate_cents_per_km : 0;
                           return formatCurrency(amountCents, 'pt-PT', activeContract?.currency || 'EUR');
                         })()}</span>
+                        {(() => {
+                          const ratePerKm = (policies.find(p => p.id === trip.policy_id)?.rate_cents_per_km) ?? 40;
+                          const { exemptCents, taxableCents } = calcMileageCap([{ km: trip.km, rateCentsPerKm: ratePerKm }], 40);
+                          return (
+                            <>
+                              <span className="text-xs text-muted-foreground">
+                                Isento: <strong>{formatCurrency(exemptCents / 100, 'pt-PT', activeContract?.currency || 'EUR')}</strong>
+                              </span>
+                              {taxableCents > 0 ? (
+                                <Badge variant="destructive" className="text-xs">
+                                  Tributável: {formatCurrency(taxableCents / 100, 'pt-PT', activeContract?.currency || 'EUR')}
+                                </Badge>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">—</span>
+                              )}
+                            </>
+                          );
+                        })()}
                         </div>
                         <div className="text-sm text-gray-600">
                           <span className="font-medium">De:</span> {trip.origin} → 
@@ -470,6 +491,34 @@ const PayrollMileagePage: React.FC = () => {
                     </div>
                   ))}
                 </div>
+
+                {/* Fiscal summary for filtered trips */}
+                {filteredTrips.length > 0 && (
+                  <div className="flex gap-6 p-3 bg-muted rounded-md text-sm mt-2">
+                    {(() => {
+                      const total = calcMileageCap(
+                        filteredTrips.map((t: any) => ({
+                          km: t.km,
+                          rateCentsPerKm: policies.find((p: any) => p.id === t.policy_id)?.rate_cents_per_km ?? 40,
+                        })),
+                        40,
+                      );
+                      return (
+                        <>
+                          <span>
+                            Total isento:{' '}
+                            <strong>{formatCurrency(total.exemptCents / 100, 'pt-PT', activeContract?.currency || 'EUR')}</strong>
+                          </span>
+                          <span>
+                            Total tributável:{' '}
+                            <strong>{formatCurrency(total.taxableCents / 100, 'pt-PT', activeContract?.currency || 'EUR')}</strong>
+                          </span>
+                        </>
+                      );
+                    })()}
+                  </div>
+                )}
+                </>
               )}
             </CardContent>
           </Card>

--- a/src/features/payroll/pages/PayrollOvertimeDetailPage.tsx
+++ b/src/features/payroll/pages/PayrollOvertimeDetailPage.tsx
@@ -13,6 +13,9 @@ import { payrollService } from '../services/payrollService';
 import { logger } from '@/shared/lib/logger';
 import { useActiveContract } from '../hooks/useActiveContract';
 import type { TimesheetEntry, OvertimeBreakdown } from '../types';
+import { buildOtDayEntries, calcOtScaled, calcOtIrsWithholding } from '../lib/calc';
+import { fetchTaxRates } from '../services/payrollAdvanced.service';
+import type { OtScaledResult } from '../types/payroll-advanced.types';
 
 interface OvertimeDetailData {
   breakdown: OvertimeBreakdown;
@@ -48,6 +51,9 @@ export default function PayrollOvertimeDetailPage() {
   const [startDateFilter, setStartDateFilter] = useState<string>('');
   const [endDateFilter, setEndDateFilter] = useState<string>('');
   const [sortAsc, setSortAsc] = useState<boolean>(true);
+  // Scaled OT (duas escalas)
+  const [scaledOtResult, setScaledOtResult] = useState<OtScaledResult | null>(null);
+  const [otIrsCents, setOtIrsCents] = useState(0);
   
 
 
@@ -317,8 +323,9 @@ export default function PayrollOvertimeDetailPage() {
       const timesheetEntries = await loadTimesheetEntries(user.id, activeContract.id, selectedYear, selectedMonth);
 
       // Buscar política de horas extras (para testes de erro específico)
+      let otPolicy: Awaited<ReturnType<typeof payrollService.getActiveOTPolicy>> | null = null;
       try {
-        await payrollService.getActiveOTPolicy(user.id, activeContract.id);
+        otPolicy = await payrollService.getActiveOTPolicy(user.id, activeContract.id);
       } catch (e) {
         toast({ title: 'Erro ao carregar política', description: 'Não foi possível carregar a política de horas extras.', variant: 'destructive' });
         throw e;
@@ -327,6 +334,28 @@ export default function PayrollOvertimeDetailPage() {
       // Calcular breakdown localmente para não depender de mocks
       const breakdown = computeBreakdownLocally(timesheetEntries);
       const monthlyStats = calculateStats(breakdown, timesheetEntries);
+
+      // Computar scaled OT (duas escalas) se a política usar defaults legais
+      if (otPolicy?.use_legal_defaults) {
+        try {
+          const taxRates = await fetchTaxRates(selectedYear ?? new Date().getFullYear());
+          const thresholdMins = ((otPolicy as any).threshold_hours ?? 8) * 60;
+          const otEntries = buildOtDayEntries(timesheetEntries, thresholdMins);
+          const baseMinuteCents = Math.round(
+            ((activeContract as any).base_salary_cents ?? 0) / (thresholdMins * 4.33)
+          );
+          const result = calcOtScaled(
+            otEntries, baseMinuteCents, (otPolicy as any).ot_hours_ytd ?? 0,
+            taxRates.otRates, taxRates.otLimits, true,
+          );
+          setScaledOtResult(result);
+          const irsRate = (activeContract as any)?.irs_rate_fraction ?? 0;
+          setOtIrsCents(calcOtIrsWithholding(
+            result.otPayCents, irsRate,
+            taxRates.otIrsWithholding.autonomous_rate_of_base,
+          ));
+        } catch { /* tax_tables may not exist yet — fail silently */ }
+      }
 
       // Se não houver entradas, ainda assim mostrar totais a zero e a mensagem exigida pelos testes
       if (timesheetEntries.length === 0) {
@@ -649,6 +678,48 @@ export default function PayrollOvertimeDetailPage() {
               </div>
             </CardContent>
           </Card>
+
+          {/* Scaled OT — duas escalas (Unit 12a) */}
+          {scaledOtResult && (
+            <Card>
+              <CardHeader>
+                <CardTitle>OT — Duas Escalas Legais</CardTitle>
+                <CardDescription>
+                  Decomposição do pagamento de horas extra segundo as escalas do CT
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">Valor OT bruto</p>
+                    <p className="text-2xl font-bold">{formatCurrency(scaledOtResult.otPayCents)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">Horas este mês</p>
+                    <p className="text-2xl font-bold">{scaledOtResult.otHoursThisMonth.toFixed(1)}h</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">Retenção IRS (OT)</p>
+                    <p className="text-2xl font-bold">{formatCurrency(otIrsCents)}</p>
+                  </div>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {scaledOtResult.dailyLimitWarning && (
+                    <Badge variant="destructive">OT diária &gt; 2h em algum dia</Badge>
+                  )}
+                  {scaledOtResult.annualLimitWarning && !scaledOtResult.annualLimitExceeded && (
+                    <Badge className="bg-amber-100 text-amber-800">A aproximar-se do limite anual</Badge>
+                  )}
+                  {scaledOtResult.annualLimitExceeded && (
+                    <Badge variant="destructive">Limite anual excedido</Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-2">
+                  YTD acumulado: {scaledOtResult.newYtdHours.toFixed(1)}h
+                </p>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Avisos */}
           {overtimeData.breakdown.validationWarnings.length > 0 && (

--- a/src/features/payroll/pages/PayrollOvertimeDetailPage.tsx
+++ b/src/features/payroll/pages/PayrollOvertimeDetailPage.tsx
@@ -717,6 +717,35 @@ export default function PayrollOvertimeDetailPage() {
                 <p className="text-xs text-muted-foreground mt-2">
                   YTD acumulado: {scaledOtResult.newYtdHours.toFixed(1)}h
                 </p>
+                {scaledOtResult.components.length > 0 && (
+                  <table className="w-full text-sm mb-3">
+                    <thead>
+                      <tr className="border-b text-muted-foreground">
+                        <th className="text-left py-1">Dia</th>
+                        <th className="text-right py-1">Escala</th>
+                        <th className="text-right py-1">Valor</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {scaledOtResult.components
+                        .filter(c => c.label.startsWith('OT ')) // exclude Night Bonus components
+                        .map((c, i) => {
+                          const isScale2 = c.label.includes('E2');
+                          return (
+                            <tr key={i} className="border-b">
+                              <td className="py-1">{c.label.replace(/^OT E[12] /, '')}</td>
+                              <td className="text-right py-1">
+                                <Badge variant={isScale2 ? 'destructive' : 'secondary'}>
+                                  {isScale2 ? 'Escala 2' : 'Escala 1'}
+                                </Badge>
+                              </td>
+                              <td className="text-right py-1">{formatCurrency(c.amount_cents)}</td>
+                            </tr>
+                          );
+                        })}
+                    </tbody>
+                  </table>
+                )}
               </CardContent>
             </Card>
           )}

--- a/src/features/payroll/pages/TravelAllowancesPage.tsx
+++ b/src/features/payroll/pages/TravelAllowancesPage.tsx
@@ -1,0 +1,192 @@
+// src/features/payroll/pages/TravelAllowancesPage.tsx
+import React, { useState, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { formatCurrency } from '@/lib/utils';
+import { useActiveContract } from '../hooks/useActiveContract';
+import { useTravelAllowances } from '../hooks/useTravelAllowances';
+import { calcTravelAllowance } from '../lib/calc';
+import type { TravelAllowanceRecord, TravelAllowanceType } from '../types/payroll-advanced.types';
+
+// 2026 caps — hardcoded for client-side preview (loaded from DB via service in Phase 2)
+const CAPS_2026 = {
+  national_general_cents: 6589, national_admin_cents: 7265,
+  foreign_general_cents: 15636, foreign_admin_cents: 17542,
+  breakdown: { lunch: 0.25, dinner: 0.25, sleep: 0.50 },
+} as const;
+
+const TYPE_LABELS: Record<TravelAllowanceType, string> = {
+  deslocacao_nacional:        'Deslocacao Nacional',
+  deslocacao_estrangeiro:     'Deslocacao Estrangeiro',
+  deslocacao_viatura_propria: 'Viatura Propria (km)',
+  alojamento:                 'Alojamento',
+};
+
+function currentPeriod(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export default function TravelAllowancesPage() {
+  const { toast } = useToast();
+  const { activeContract } = useActiveContract();
+  const period = currentPeriod();
+  const { allowances, save, remove } = useTravelAllowances(activeContract?.id ?? null, period);
+
+  const [type, setType] = useState<TravelAllowanceType>('deslocacao_nacional');
+  const [role, setRole] = useState<'general' | 'admin'>('general');
+  const [dateStart, setDateStart] = useState('');
+  const [days, setDays] = useState('');
+  const [km, setKm] = useState('');
+  const [declaredEuros, setDeclaredEuros] = useState('');
+
+  const declaredCents = Math.round(parseFloat(declaredEuros || '0') * 100);
+  const daysNum = parseFloat(days || '1');
+  const kmNum   = parseFloat(km || '0');
+
+  const preview = useMemo(() => {
+    if (declaredCents <= 0) return null;
+    return calcTravelAllowance(
+      { type, days: daysNum, km: type === 'deslocacao_viatura_propria' ? kmNum : undefined, role, declaredCents },
+      CAPS_2026,
+      40,
+    );
+  }, [type, role, daysNum, kmNum, declaredCents]);
+
+  const handleSave = async () => {
+    if (!activeContract?.id) return;
+    try {
+      await save.mutateAsync({
+        contract_id:          activeContract.id,
+        type,
+        date_start:           dateStart || new Date().toISOString().split('T')[0],
+        days:                 type !== 'deslocacao_viatura_propria' ? daysNum : undefined,
+        km:                   type === 'deslocacao_viatura_propria' ? kmNum : undefined,
+        role,
+        declared_cents:       declaredCents,
+        taxable_excess_cents: preview?.taxableExcessCents ?? 0,
+        operation_id:         `${activeContract.id}-${Date.now()}`,
+      });
+      toast({ title: 'Guardado', description: 'Ajuda de custo registada.' });
+      setDeclaredEuros(''); setDays(''); setKm(''); setDateStart('');
+    } catch (e: any) {
+      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Ajudas de Custo</h1>
+
+      <Card>
+        <CardHeader><CardTitle>Registar ajuda de custo</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label>Tipo</Label>
+              <Select value={type} onValueChange={(v) => setType(v as TravelAllowanceType)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(TYPE_LABELS) as [TravelAllowanceType, string][]).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label>Perfil</Label>
+              <Select value={role} onValueChange={(v) => setRole(v as 'general' | 'admin')}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="general">Geral</SelectItem>
+                  <SelectItem value="admin">Administrador</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label>Data inicio</Label>
+              <Input type="date" value={dateStart} onChange={e => setDateStart(e.target.value)} />
+            </div>
+
+            {type !== 'deslocacao_viatura_propria' ? (
+              <div className="space-y-1">
+                <Label>Dias</Label>
+                <Input type="number" step="0.5" min="0.5" value={days} onChange={e => setDays(e.target.value)} placeholder="ex: 3" />
+              </div>
+            ) : (
+              <div className="space-y-1">
+                <Label>Quilometros</Label>
+                <Input type="number" step="1" min="1" value={km} onChange={e => setKm(e.target.value)} placeholder="ex: 150" />
+              </div>
+            )}
+
+            <div className="space-y-1 col-span-2">
+              <Label htmlFor="valor-declarado">Valor declarado (EUR)</Label>
+              <Input
+                id="valor-declarado"
+                type="number" step="0.01"
+                value={declaredEuros}
+                onChange={e => setDeclaredEuros(e.target.value)}
+                placeholder="ex: 197.67"
+              />
+            </div>
+          </div>
+
+          {preview && (
+            <div className="flex gap-4 p-3 bg-muted rounded-md text-sm">
+              <span>Isento: <strong>{formatCurrency(preview.exemptCents / 100)}</strong></span>
+              <span>Tributavel: <strong>{formatCurrency(preview.taxableExcessCents / 100)}</strong></span>
+            </div>
+          )}
+
+          <Button onClick={handleSave} disabled={save.isPending}>Guardar</Button>
+        </CardContent>
+      </Card>
+
+      {allowances.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle>Ajudas do mes</CardTitle></CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-2">Tipo</th>
+                  <th className="text-left py-2">Data</th>
+                  <th className="text-right py-2">Declarado</th>
+                  <th className="text-right py-2">Isento</th>
+                  <th className="text-right py-2">Tributavel</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {allowances.map((a: TravelAllowanceRecord) => (
+                  <tr key={a.id} className="border-b">
+                    <td className="py-2">{TYPE_LABELS[a.type as TravelAllowanceType]}</td>
+                    <td className="py-2">{a.date_start}</td>
+                    <td className="text-right py-2">{formatCurrency(a.declared_cents / 100)}</td>
+                    <td className="text-right py-2">{formatCurrency((a.declared_cents - a.taxable_excess_cents) / 100)}</td>
+                    <td className="text-right py-2">
+                      {a.taxable_excess_cents > 0 && (
+                        <Badge variant="destructive">{formatCurrency(a.taxable_excess_cents / 100)}</Badge>
+                      )}
+                    </td>
+                    <td className="py-2">
+                      <Button variant="ghost" size="sm" onClick={() => remove.mutate(a.id)}>x</Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/features/payroll/services/__tests__/payrollAdvancedService.test.ts
+++ b/src/features/payroll/services/__tests__/payrollAdvancedService.test.ts
@@ -1,0 +1,207 @@
+// src/features/payroll/services/__tests__/payrollAdvancedService.test.ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  fetchTaxRates,
+  _clearTaxRateCache,
+  fetchTravelAllowances,
+  saveTravelAllowance,
+  deleteTravelAllowance,
+  updateOtYtd,
+} from '../payrollAdvanced.service';
+
+// Mock Supabase — must use the same alias as the source file
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+import { supabase } from '@/lib/supabaseClient';
+
+const TAX_ROWS = [
+  {
+    type: 'ot_rates',
+    data: {
+      up_to_100h: { first_hour_pct: 0.25, next_hours_pct: 0.375, rest_day_pct: 0.50 },
+      above_100h: { first_hour_pct: 0.50, next_hours_pct: 0.75, rest_day_pct: 1.00 },
+      night_work_pct: 0.25, night_start: '22:00', night_end: '07:00',
+    },
+  },
+  {
+    type: 'ot_annual_limits',
+    data: { mpe_hours: 175, others_hours: 150, irct_max_hours: 200, daily_max_hours: 2 },
+  },
+  {
+    type: 'ot_irs_withholding',
+    data: { autonomous_rate_of_base: 0.50, since: '2025-01-01' },
+  },
+  {
+    type: 'mileage_caps',
+    data: { cents_per_km: 40 },
+  },
+  {
+    type: 'travel_allowance_caps',
+    data: {
+      national_general_cents: 6589, national_admin_cents: 7265,
+      foreign_general_cents: 15636, foreign_admin_cents: 17542,
+      breakdown: { lunch: 0.25, dinner: 0.25, sleep: 0.50 },
+    },
+  },
+];
+
+/**
+ * Creates a Supabase chain mock.
+ *
+ * All chainable methods return `this` so the full builder chain works.
+ * The chain object is also thenable (has a `.then` method) so it can be
+ * `await`ed directly when it is the last expression in the service function
+ * (e.g. `await supabase.from(...).delete().eq(...)`).
+ * Methods that Supabase-JS always makes terminal (.single) are also resolved.
+ */
+function mockChain(returnData: any, returnError: any = null) {
+  const resolved = { data: returnData, error: returnError };
+  // Make the chain itself a thenable so `await chain` works at any point
+  const promise = Promise.resolve(resolved);
+  const chain: Record<string, any> = {
+    select: vi.fn().mockReturnThis(),
+    eq:     vi.fn().mockReturnThis(),
+    gte:    vi.fn().mockReturnThis(),
+    lte:    vi.fn().mockReturnThis(),
+    order:  vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(resolved),
+    // Thenable — allows `await chain` and `await chain.someMethod(...)`
+    then:   (onFulfilled: any, onRejected: any) => promise.then(onFulfilled, onRejected),
+    catch:  (onRejected: any) => promise.catch(onRejected),
+    finally: (onFinally: any) => promise.finally(onFinally),
+  };
+  (supabase.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  return chain;
+}
+
+// ── fetchTaxRates ─────────────────────────────────────────────────────────────
+
+describe('fetchTaxRates', () => {
+  beforeEach(() => _clearTaxRateCache());
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns correct rates from DB', async () => {
+    mockChain(TAX_ROWS);
+    const rates = await fetchTaxRates(2026);
+    expect(rates.otRates.up_to_100h.first_hour_pct).toBe(0.25);
+    expect(rates.mileageCaps.cents_per_km).toBe(40);
+    expect(rates.travelCaps.national_general_cents).toBe(6589);
+    expect(rates.otIrsWithholding.autonomous_rate_of_base).toBe(0.50);
+  });
+
+  it('caches results — only one DB call on second fetch', async () => {
+    mockChain(TAX_ROWS);
+    await fetchTaxRates(2026);
+    await fetchTaxRates(2026);
+    expect(supabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches again after cache is cleared', async () => {
+    mockChain(TAX_ROWS);
+    await fetchTaxRates(2026);
+    _clearTaxRateCache();
+    mockChain(TAX_ROWS); // re-mock for the second call
+    await fetchTaxRates(2026);
+    expect(supabase.from).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when a required type is missing from DB', async () => {
+    // Remove ot_rates from the rows
+    const partial = TAX_ROWS.filter(r => r.type !== 'ot_rates');
+    mockChain(partial);
+    await expect(fetchTaxRates(2026)).rejects.toThrow('Missing ot_rates');
+  });
+});
+
+// ── fetchTravelAllowances ─────────────────────────────────────────────────────
+
+describe('fetchTravelAllowances', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('queries by contract and period date range', async () => {
+    const records = [
+      {
+        id: 'a', contract_id: 'c1', type: 'deslocacao_nacional',
+        date_start: '2026-01-10', days: 2, km: null, role: 'general',
+        declared_cents: 13178, taxable_excess_cents: 0, operation_id: 'op1', created_at: '',
+      },
+    ];
+    const chain = mockChain(records);
+    const result = await fetchTravelAllowances('c1', '2026-01');
+    expect(supabase.from).toHaveBeenCalledWith('payroll_travel_allowances');
+    expect(chain.gte).toHaveBeenCalledWith('date_start', '2026-01-01');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('returns empty array when no records', async () => {
+    mockChain([]);
+    const result = await fetchTravelAllowances('c1', '2026-02');
+    expect(result).toEqual([]);
+  });
+});
+
+// ── saveTravelAllowance ───────────────────────────────────────────────────────
+
+describe('saveTravelAllowance', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('inserts into payroll_travel_allowances and returns record', async () => {
+    const inserted = {
+      id: 'new-id', contract_id: 'c1', type: 'deslocacao_nacional',
+      date_start: '2026-01-10', days: 2, km: null, role: 'general',
+      declared_cents: 13178, taxable_excess_cents: 0, operation_id: 'op-1', created_at: '',
+    };
+    const chain = mockChain(inserted);
+    const result = await saveTravelAllowance({
+      contract_id: 'c1', type: 'deslocacao_nacional', date_start: '2026-01-10',
+      days: 2, role: 'general', declared_cents: 13178, taxable_excess_cents: 0, operation_id: 'op-1',
+    });
+    expect(supabase.from).toHaveBeenCalledWith('payroll_travel_allowances');
+    expect(chain.insert).toHaveBeenCalled();
+    expect(result.id).toBe('new-id');
+  });
+
+  it('propagates Supabase error', async () => {
+    mockChain(null, { message: 'DB error', code: '23505' });
+    await expect(saveTravelAllowance({
+      contract_id: 'c1', type: 'deslocacao_nacional', date_start: '2026-01-10',
+      role: 'general', declared_cents: 100, taxable_excess_cents: 0, operation_id: 'op-2',
+    })).rejects.toThrow();
+  });
+});
+
+// ── deleteTravelAllowance ─────────────────────────────────────────────────────
+
+describe('deleteTravelAllowance', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('calls DELETE with correct id', async () => {
+    const chain = mockChain(null);
+    await deleteTravelAllowance('record-id');
+    expect(supabase.from).toHaveBeenCalledWith('payroll_travel_allowances');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', 'record-id');
+  });
+});
+
+// ── updateOtYtd ───────────────────────────────────────────────────────────────
+
+describe('updateOtYtd', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('updates ot_hours_ytd on payroll_ot_policies', async () => {
+    const chain = mockChain(null);
+    await updateOtYtd('contract-1', 52.5);
+    expect(supabase.from).toHaveBeenCalledWith('payroll_ot_policies');
+    expect(chain.update).toHaveBeenCalledWith({ ot_hours_ytd: 52.5 });
+    expect(chain.eq).toHaveBeenCalledWith('contract_id', 'contract-1');
+  });
+});

--- a/src/features/payroll/services/__tests__/payrollCoreService.test.ts
+++ b/src/features/payroll/services/__tests__/payrollCoreService.test.ts
@@ -31,6 +31,14 @@ describe('calculatePayslip', () => {
       error: null,
     });
 
+    // Phase 2: getOTPoliciesByContract returns empty → early-return path (no legal-defaults policy)
+    const mockOtPolicyChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    mockFrom.mockReturnValue(mockOtPolicyChain);
+
     const result = await calculatePayslip('contract-123', '2026-05');
 
     expect(mockRpc).toHaveBeenCalledWith('calculate_payslip', {

--- a/src/features/payroll/services/payrollAdvanced.service.ts
+++ b/src/features/payroll/services/payrollAdvanced.service.ts
@@ -1,0 +1,84 @@
+// src/features/payroll/services/payrollAdvanced.service.ts
+import { supabase } from '../../../lib/supabaseClient';
+import type { TaxRates, TravelAllowanceRecord, TravelAllowanceInput } from '../types/payroll-advanced.types';
+
+// ── Tax rate cache (1h TTL) ────────────────────────────────────────────────────
+
+const taxRateCache = new Map<number, { data: TaxRates; expiresAt: number }>();
+
+export async function fetchTaxRates(year: number): Promise<TaxRates> {
+  const cached = taxRateCache.get(year);
+  if (cached && Date.now() < cached.expiresAt) return cached.data;
+
+  const { data, error } = await supabase
+    .from('tax_tables')
+    .select('type, data')
+    .eq('effective_year', year);
+  if (error) throw error;
+
+  const byType = Object.fromEntries((data ?? []).map((r: any) => [r.type, r.data]));
+
+  const rates: TaxRates = {
+    otRates:          byType['ot_rates']          ?? (() => { throw new Error('Missing ot_rates'); })(),
+    otLimits:         byType['ot_annual_limits']  ?? (() => { throw new Error('Missing ot_annual_limits'); })(),
+    otIrsWithholding: byType['ot_irs_withholding'] ?? (() => { throw new Error('Missing ot_irs_withholding'); })(),
+    mileageCaps:      byType['mileage_caps']       ?? (() => { throw new Error('Missing mileage_caps'); })(),
+    travelCaps:       byType['travel_allowance_caps'] ?? (() => { throw new Error('Missing travel_allowance_caps'); })(),
+  };
+
+  taxRateCache.set(year, { data: rates, expiresAt: Date.now() + 60 * 60 * 1000 });
+  return rates;
+}
+
+// Exported for testing only — clears the in-memory cache
+export function _clearTaxRateCache() { taxRateCache.clear(); }
+
+// ── Travel allowances CRUD ─────────────────────────────────────────────────────
+
+/** Returns travel allowances for a contract where date_start falls within period (YYYY-MM). */
+export async function fetchTravelAllowances(
+  contractId: string,
+  period: string, // 'YYYY-MM'
+): Promise<TravelAllowanceRecord[]> {
+  const [year, month] = period.split('-').map(Number);
+  const dateStart = `${period}-01`;
+  const dateEnd   = new Date(year, month, 0).toISOString().split('T')[0]; // last day
+
+  const { data, error } = await supabase
+    .from('payroll_travel_allowances')
+    .select('*')
+    .eq('contract_id', contractId)
+    .gte('date_start', dateStart)
+    .lte('date_start', dateEnd)
+    .order('date_start', { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as TravelAllowanceRecord[];
+}
+
+export async function saveTravelAllowance(input: TravelAllowanceInput): Promise<TravelAllowanceRecord> {
+  const { data, error } = await supabase
+    .from('payroll_travel_allowances')
+    .insert(input)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as TravelAllowanceRecord;
+}
+
+export async function deleteTravelAllowance(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('payroll_travel_allowances')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}
+
+// ── OT YTD tracker ────────────────────────────────────────────────────────────
+
+export async function updateOtYtd(contractId: string, newYtdHours: number): Promise<void> {
+  const { error } = await supabase
+    .from('payroll_ot_policies')
+    .update({ ot_hours_ytd: newYtdHours })
+    .eq('contract_id', contractId);
+  if (error) throw error;
+}

--- a/src/features/payroll/services/payrollAdvanced.service.ts
+++ b/src/features/payroll/services/payrollAdvanced.service.ts
@@ -11,7 +11,7 @@ export async function fetchTaxRates(year: number): Promise<TaxRates> {
   if (cached && Date.now() < cached.expiresAt) return cached.data;
 
   const { data, error } = await supabase
-    .from('tax_tables')
+    .from('payroll_fiscal_params')
     .select('type, data')
     .eq('effective_year', year);
   if (error) throw error;

--- a/src/features/payroll/services/payrollService.ts
+++ b/src/features/payroll/services/payrollService.ts
@@ -1673,16 +1673,110 @@ export async function recalculatePayroll(
 // Unit 11 — Payroll Core: RPC-backed methods
 // ─────────────────────────────────────────────────────────────────
 
+/** Fetches leaves for a contract within a date range — used by the Phase 2 calc engine. */
+export async function getLeavesByContractPeriod(
+  contractId: string,
+  startDate: string,
+  endDate: string,
+): Promise<any[]> {
+  const { data, error } = await supabase
+    .from('payroll_leaves')
+    .select('*')
+    .eq('contract_id', contractId)
+    .gte('start_date', startDate)
+    .lte('end_date', endDate);
+  if (error) throw error;
+  return data ?? [];
+}
+
 export const calculatePayslip = async (
   contractId: string,
   period: string,
 ): Promise<PayslipCalculation> => {
-  const { data, error } = await supabase.rpc('calculate_payslip', {
+  // ── Phase 1: RPC base calculation (IRS brackets, SS, meal) ──────────────────
+  const { data: base, error } = await supabase.rpc('calculate_payslip', {
     p_contract_id: contractId,
     p_period: period,
   });
   if (error) throw error;
-  return data as PayslipCalculation;
+  const baseResult = base as PayslipCalculation;
+
+  // ── Phase 2: fetch fiscal inputs + TypeScript calc engine ────────────────────
+  const {
+    fetchTaxRates: fetchRates,
+    fetchTravelAllowances: fetchAllowances,
+  } = await import('./payrollAdvanced.service');
+  const {
+    buildOtDayEntries,
+    calcOtScaled,
+    calcOtIrsWithholding,
+    calcMileageCap,
+    calcTravelAllowance,
+    calcLeaveImpact,
+    mergeComponents,
+  } = await import('../lib/calc');
+
+  const [year, month] = period.split('-').map(Number);
+
+  // Fetch OT policy to get threshold_hours, ot_hours_ytd, isMPE flag
+  const otPolicies = await getOTPoliciesByContract(contractId);
+  const otPolicy = otPolicies[0] ?? null;
+  if (!otPolicy || !otPolicy.use_legal_defaults) {
+    // No legal-defaults policy: return base calculation unchanged
+    return baseResult;
+  }
+
+  const firstDay = `${period}-01`;
+  const lastDay  = new Date(year, month, 0).toISOString().split('T')[0];
+
+  const [rawTimeEntries, mileageTrips, travelAllowances, leaves, taxRates] = await Promise.all([
+    getTimeEntriesByContract(null as any, contractId),
+    getMileageTrips(null as any, firstDay, lastDay, contractId),
+    fetchAllowances(contractId, period),
+    getLeavesByContractPeriod(contractId, firstDay, lastDay),
+    fetchRates(new Date().getFullYear()),
+  ]);
+
+  const thresholdMins   = (otPolicy.threshold_hours ?? 8) * 60;
+  const otEntries       = buildOtDayEntries(rawTimeEntries ?? [], thresholdMins);
+  const baseMinuteCents = thresholdMins > 0
+    ? Math.round(baseResult.gross_cents / (thresholdMins * 4.33))
+    : 0;
+  const irsRateFraction = baseResult.gross_cents > 0
+    ? baseResult.irs_cents / baseResult.gross_cents
+    : 0;
+
+  const otResult    = calcOtScaled(
+    otEntries, baseMinuteCents, (otPolicy as any).ot_hours_ytd ?? 0,
+    taxRates.otRates, taxRates.otLimits,
+    (otPolicy as any).isMPE ?? true, // TODO(12b): add isMPE column to payroll_ot_policies
+  );
+  const otIrsCents  = calcOtIrsWithholding(
+    otResult.otPayCents, irsRateFraction,
+    taxRates.otIrsWithholding.autonomous_rate_of_base,
+  );
+  const mileage     = calcMileageCap(
+    (mileageTrips ?? []).map((t: any) => ({ km: t.km, rateCentsPerKm: t.rate_cents_per_km ?? 40 })),
+    taxRates.mileageCaps.cents_per_km,
+  );
+  const allowances  = (travelAllowances ?? []).map((a: any) => calcTravelAllowance(
+    { type: a.type, days: a.days ?? 1, km: a.km ?? undefined, role: a.role, declaredCents: a.declared_cents },
+    taxRates.travelCaps, taxRates.mileageCaps.cents_per_km,
+  ));
+  const grossDailyCents = baseResult.working_days > 0
+    ? Math.round(baseResult.gross_cents / baseResult.working_days)
+    : 0;
+  const leaveImpact = calcLeaveImpact(
+    (leaves ?? []).map((l: any) => ({
+      leaveType:      l.leave_type,
+      totalDays:      l.total_days,
+      employerDays:   l.employer_days ?? 3,
+      affectsSubsidy: l.affects_subsidy ?? false,
+    })),
+    grossDailyCents,
+  );
+
+  return mergeComponents(baseResult, otResult, otIrsCents, mileage, allowances, leaveImpact);
 };
 
 export const createPayslipDraft = async (

--- a/src/features/payroll/services/payrollService.ts
+++ b/src/features/payroll/services/payrollService.ts
@@ -1718,24 +1718,25 @@ export const calculatePayslip = async (
 
   const [year, month] = period.split('-').map(Number);
 
-  // Fetch OT policy to get threshold_hours, ot_hours_ytd, isMPE flag
+  // Fetch OT policy to get threshold_hours, ot_hours_ytd, use_legal_defaults flag
   const otPolicies = await getOTPoliciesByContract(contractId);
   const otPolicy = otPolicies[0] ?? null;
-  if (!otPolicy || !(otPolicy as any).use_legal_defaults) {
+  if (!otPolicy || !otPolicy.use_legal_defaults) {
     // No legal-defaults policy: return base calculation unchanged
     return baseResult;
   }
 
   const firstDay = `${period}-01`;
-  const lastDay  = new Date(year, month, 0).toISOString().split('T')[0];
+  const lastDay  = getLastDayOfMonth(year, month); // local-safe (no UTC shift)
 
-  // Fetch user_id needed for time entries and mileage queries
+  // Fetch user_id + weekly_hours needed for time entries and baseMinuteCents
   const contractData = await supabase
     .from('payroll_contracts')
-    .select('user_id')
+    .select('user_id, weekly_hours')
     .eq('id', contractId)
     .single();
-  const userId: string = contractData.data?.user_id ?? '';
+  const userId: string  = contractData.data?.user_id ?? '';
+  const weeklyHours: number = contractData.data?.weekly_hours ?? 40;
 
   const [rawTimeEntries, mileageTrips, travelAllowances, leaves, taxRates] = await Promise.all([
     getTimeEntriesByContract(userId, contractId),
@@ -1747,17 +1748,20 @@ export const calculatePayslip = async (
 
   const thresholdMins   = (otPolicy.threshold_hours ?? 8) * 60;
   const otEntries       = buildOtDayEntries(rawTimeEntries ?? [], thresholdMins);
-  const baseMinuteCents = thresholdMins > 0
-    ? Math.round(baseResult.gross_cents / (thresholdMins * 4.33))
+  // baseMinuteCents: cents per minute of normal work time.
+  // Monthly minutes = weekly_hours × 4.33 weeks × 60 min/h
+  const monthlyWorkMins = weeklyHours * 4.33 * 60;
+  const baseMinuteCents = monthlyWorkMins > 0
+    ? Math.round(baseResult.gross_cents / monthlyWorkMins)
     : 0;
   const irsRateFraction = baseResult.gross_cents > 0
     ? baseResult.irs_cents / baseResult.gross_cents
     : 0;
 
   const otResult    = calcOtScaled(
-    otEntries, baseMinuteCents, (otPolicy as any).ot_hours_ytd ?? 0,
+    otEntries, baseMinuteCents, otPolicy.ot_hours_ytd ?? 0,
     taxRates.otRates, taxRates.otLimits,
-    (otPolicy as any).isMPE ?? true, // TODO(12b): add isMPE column to payroll_ot_policies
+    false, // TODO(12b): add isMPE column to payroll_ot_policies
   );
   const otIrsCents  = calcOtIrsWithholding(
     otResult.otPayCents, irsRateFraction,

--- a/src/features/payroll/services/payrollService.ts
+++ b/src/features/payroll/services/payrollService.ts
@@ -1721,7 +1721,7 @@ export const calculatePayslip = async (
   // Fetch OT policy to get threshold_hours, ot_hours_ytd, isMPE flag
   const otPolicies = await getOTPoliciesByContract(contractId);
   const otPolicy = otPolicies[0] ?? null;
-  if (!otPolicy || !otPolicy.use_legal_defaults) {
+  if (!otPolicy || !(otPolicy as any).use_legal_defaults) {
     // No legal-defaults policy: return base calculation unchanged
     return baseResult;
   }
@@ -1729,12 +1729,20 @@ export const calculatePayslip = async (
   const firstDay = `${period}-01`;
   const lastDay  = new Date(year, month, 0).toISOString().split('T')[0];
 
+  // Fetch user_id needed for time entries and mileage queries
+  const contractData = await supabase
+    .from('payroll_contracts')
+    .select('user_id')
+    .eq('id', contractId)
+    .single();
+  const userId: string = contractData.data?.user_id ?? '';
+
   const [rawTimeEntries, mileageTrips, travelAllowances, leaves, taxRates] = await Promise.all([
-    getTimeEntriesByContract(null as any, contractId),
-    getMileageTrips(null as any, firstDay, lastDay, contractId),
+    getTimeEntriesByContract(userId, contractId),
+    getMileageTrips(userId, firstDay, lastDay, contractId),
     fetchAllowances(contractId, period),
     getLeavesByContractPeriod(contractId, firstDay, lastDay),
-    fetchRates(new Date().getFullYear()),
+    fetchRates(year),
   ]);
 
   const thresholdMins   = (otPolicy.threshold_hours ?? 8) * 60;

--- a/src/features/payroll/types/index.ts
+++ b/src/features/payroll/types/index.ts
@@ -41,6 +41,9 @@ export interface PayrollOTPolicy {
   night_end_time: string; // Fim período noturno
   rounding_minutes: number; // Arredondamento em minutos
   is_active: boolean;
+  // Unit 12a additions
+  ot_hours_ytd: number;        // Running YTD overtime hour counter (resets each year)
+  use_legal_defaults: boolean; // Enables Phase 2 Motor Fiscal TypeScript calc engine
   created_at: string;
   updated_at: string;
 }

--- a/src/features/payroll/types/payroll-advanced.types.ts
+++ b/src/features/payroll/types/payroll-advanced.types.ts
@@ -1,0 +1,137 @@
+// src/features/payroll/types/payroll-advanced.types.ts
+// Unit 12a — Motor Fiscal PT type definitions
+
+// ── OT Rates (Lei 13/2023) ────────────────────────────────────────────────────
+
+export interface OtScale {
+  first_hour_pct: number;   // % premium for first OT hour
+  next_hours_pct: number;   // % premium for subsequent OT hours
+  rest_day_pct:   number;   // % premium for rest/holiday day OT
+}
+
+export interface OtRates {
+  up_to_100h:    OtScale;   // Escala 1: YTD OT hours ≤ 100
+  above_100h:    OtScale;   // Escala 2: YTD OT hours > 100
+  night_work_pct: number;   // Additional % for night OT
+  night_start:    string;   // e.g. "22:00"
+  night_end:      string;   // e.g. "07:00"
+}
+
+export interface OtAnnualLimits {
+  mpe_hours:       number;  // MPE (micro/small): 175h
+  others_hours:    number;  // Other companies: 150h
+  irct_max_hours:  number;  // With IRCT agreement: up to 200h
+  daily_max_hours: number;  // Max OT per day: 2h
+}
+
+// ── Mileage / Travel Allowance Caps ──────────────────────────────────────────
+
+export interface MileageCaps {
+  cents_per_km: number;     // AT cap: 40 cents/km for 2026
+}
+
+export interface TravelAllowanceCaps {
+  national_general_cents: number;   // €65,89/day for general staff
+  national_admin_cents:   number;   // €72,65/day for admin/managers
+  foreign_general_cents:  number;   // €156,36/day for general staff abroad
+  foreign_admin_cents:    number;   // €175,42/day for admin/managers abroad
+  breakdown: {
+    lunch:  number;   // fraction of daily rate: 0.25
+    dinner: number;   // fraction of daily rate: 0.25
+    sleep:  number;   // fraction of daily rate: 0.50
+  };
+}
+
+// ── OT Computation Inputs ─────────────────────────────────────────────────────
+
+/** One day's worth of OT data, derived from PayrollTimeEntry[] */
+export interface OtDayEntry {
+  date:          string;   // ISO date "YYYY-MM-DD"
+  otMinutes:     number;   // minutes of OT beyond threshold
+  isRestDay:     boolean;  // Sunday or public holiday
+  nightMinutes:  number;   // OT minutes that fall in 22:00–07:00
+}
+
+/** Result of calcOtScaled — the full scaled OT output */
+export interface OtScaledResult {
+  otPayCents:         number;
+  otHoursThisMonth:   number;
+  newYtdHours:        number;
+  nightBonusCents:    number;
+  dailyLimitWarning:  boolean;  // any day exceeded 2h OT
+  annualLimitWarning: boolean;  // newYtdHours within 10h of annual limit
+  annualLimitExceeded:boolean;  // newYtdHours >= annual limit
+  components: {
+    label:        string;  // e.g. "OT E1 2026-01-06" or "OT E2 2026-01-06"
+    amount_cents: number;
+    sign:         '+' | '-';
+  }[];
+}
+
+// ── Leaves ────────────────────────────────────────────────────────────────────
+
+export interface LeaveRecord {
+  leaveType:       'sick' | 'unpaid' | 'maternity' | 'paternity' | 'vacation' | string;
+  totalDays:       number;
+  employerDays:    number;   // days employer pays (default 3 for sick)
+  affectsSubsidy:  boolean;  // true if this vacation reduces subsidy pro-rata
+}
+
+export interface LeaveImpact {
+  unpaidDeductionCents:    number;
+  subsidyAdjustmentCents: number;
+  components: {
+    label:        string;
+    amount_cents: number;
+    sign:         '+' | '-';
+  }[];
+}
+
+// ── Travel Allowances (DB record) ─────────────────────────────────────────────
+
+export type TravelAllowanceType =
+  | 'deslocacao_nacional'
+  | 'deslocacao_estrangeiro'
+  | 'deslocacao_viatura_propria'
+  | 'alojamento';
+
+export interface TravelAllowanceRecord {
+  id:                   string;
+  contract_id:          string;
+  type:                 TravelAllowanceType;
+  date_start:           string;  // ISO date
+  days:                 number | null;
+  km:                   number | null;
+  role:                 'general' | 'admin';
+  declared_cents:       number;
+  taxable_excess_cents: number;
+  operation_id:         string;
+  created_at:           string;
+}
+
+export interface TravelAllowanceInput {
+  contract_id:          string;
+  type:                 TravelAllowanceType;
+  date_start:           string;
+  days?:                number;
+  km?:                  number;
+  role:                 'general' | 'admin';
+  declared_cents:       number;
+  taxable_excess_cents: number;
+  operation_id:         string;
+}
+
+// ── Aggregated Tax Rates (fetched from tax_tables) ────────────────────────────
+
+export interface OtIrsWithholding {
+  autonomous_rate_of_base: number;  // 0.50 — 50% of base IRS rate
+  since:                   string;  // "2025-01-01"
+}
+
+export interface TaxRates {
+  otRates:          OtRates;
+  otLimits:         OtAnnualLimits;
+  otIrsWithholding: OtIrsWithholding;
+  mileageCaps:      MileageCaps;
+  travelCaps:       TravelAllowanceCaps;
+}

--- a/supabase/migrations/20260507100000_unit12a_tax_tables.sql
+++ b/supabase/migrations/20260507100000_unit12a_tax_tables.sql
@@ -12,8 +12,12 @@ CREATE TABLE IF NOT EXISTS tax_tables (
 
 -- Enable RLS (read-only for authenticated users; writes via service role)
 ALTER TABLE tax_tables ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "authenticated read tax_tables"
-  ON tax_tables FOR SELECT TO authenticated USING (true);
+DO $$
+BEGIN
+  CREATE POLICY "authenticated read tax_tables"
+    ON tax_tables FOR SELECT TO authenticated USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- ── 2026 seed data ─────────────────────────────────────────────────────────────
 

--- a/supabase/migrations/20260507100000_unit12a_tax_tables.sql
+++ b/supabase/migrations/20260507100000_unit12a_tax_tables.sql
@@ -1,0 +1,80 @@
+-- Migration 1: tax_tables — fiscal rate store for Unit 12a
+-- Creates the tax_tables table and seeds 2026 fiscal values
+
+CREATE TABLE IF NOT EXISTS tax_tables (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  effective_year  integer NOT NULL,
+  type            text    NOT NULL,
+  data            jsonb   NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (effective_year, type)
+);
+
+-- Enable RLS (read-only for authenticated users; writes via service role)
+ALTER TABLE tax_tables ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "authenticated read tax_tables"
+  ON tax_tables FOR SELECT TO authenticated USING (true);
+
+-- ── 2026 seed data ─────────────────────────────────────────────────────────────
+
+-- OT rates (Lei 13/2023, duas escalas: até 100h / acima 100h)
+INSERT INTO tax_tables (effective_year, type, data) VALUES
+(2026, 'ot_rates', '{
+  "up_to_100h": {
+    "first_hour_pct": 0.25,
+    "next_hours_pct": 0.375,
+    "rest_day_pct":   0.50
+  },
+  "above_100h": {
+    "first_hour_pct": 0.50,
+    "next_hours_pct": 0.75,
+    "rest_day_pct":   1.00
+  },
+  "night_work_pct": 0.25,
+  "night_start": "22:00",
+  "night_end":   "07:00"
+}'::jsonb)
+ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
+
+-- OT annual limits (hours)
+INSERT INTO tax_tables (effective_year, type, data) VALUES
+(2026, 'ot_annual_limits', '{
+  "mpe_hours":       175,
+  "others_hours":    150,
+  "irct_max_hours":  200,
+  "daily_max_hours": 2
+}'::jsonb)
+ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
+
+-- OT IRS withholding (IRS autónomo em OT desde 2025: 50% da taxa base)
+INSERT INTO tax_tables (effective_year, type, data) VALUES
+(2026, 'ot_irs_withholding', '{
+  "autonomous_rate_of_base": 0.50,
+  "since": "2025-01-01"
+}'::jsonb)
+ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
+
+-- Mileage caps (cap AT 2026: €0,40/km)
+INSERT INTO tax_tables (effective_year, type, data) VALUES
+(2026, 'mileage_caps', '{
+  "cents_per_km": 40
+}'::jsonb)
+ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
+
+-- Travel allowance caps 2026 (PT law)
+-- national_general: €65,89/day | national_admin: €72,65/day
+-- foreign_general: €156,36/day | foreign_admin: €175,42/day
+-- breakdown: lunch 25%, dinner 25%, sleep 50%
+INSERT INTO tax_tables (effective_year, type, data) VALUES
+(2026, 'travel_allowance_caps', '{
+  "national_general_cents": 6589,
+  "national_admin_cents":   7265,
+  "foreign_general_cents":  15636,
+  "foreign_admin_cents":    17542,
+  "breakdown": {
+    "lunch":  0.25,
+    "dinner": 0.25,
+    "sleep":  0.50
+  }
+}'::jsonb)
+ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;

--- a/supabase/migrations/20260507100000_unit12a_tax_tables.sql
+++ b/supabase/migrations/20260507100000_unit12a_tax_tables.sql
@@ -1,7 +1,8 @@
--- Migration 1: tax_tables — fiscal rate store for Unit 12a
--- Creates the tax_tables table and seeds 2026 fiscal values
+-- Migration 1: payroll_fiscal_params — fiscal rate store for Unit 12a
+-- Creates the payroll_fiscal_params table and seeds 2026 fiscal values.
+-- NOTE: Does NOT reuse the Unit 11 tax_tables (IRS bracket columns) — different schema.
 
-CREATE TABLE IF NOT EXISTS tax_tables (
+CREATE TABLE IF NOT EXISTS payroll_fiscal_params (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   effective_year  integer NOT NULL,
   type            text    NOT NULL,
@@ -11,18 +12,18 @@ CREATE TABLE IF NOT EXISTS tax_tables (
 );
 
 -- Enable RLS (read-only for authenticated users; writes via service role)
-ALTER TABLE tax_tables ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payroll_fiscal_params ENABLE ROW LEVEL SECURITY;
 DO $$
 BEGIN
-  CREATE POLICY "authenticated read tax_tables"
-    ON tax_tables FOR SELECT TO authenticated USING (true);
+  CREATE POLICY "authenticated read payroll_fiscal_params"
+    ON payroll_fiscal_params FOR SELECT TO authenticated USING (true);
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
 -- ── 2026 seed data ─────────────────────────────────────────────────────────────
 
 -- OT rates (Lei 13/2023, duas escalas: até 100h / acima 100h)
-INSERT INTO tax_tables (effective_year, type, data) VALUES
+INSERT INTO payroll_fiscal_params (effective_year, type, data) VALUES
 (2026, 'ot_rates', '{
   "up_to_100h": {
     "first_hour_pct": 0.25,
@@ -41,7 +42,7 @@ INSERT INTO tax_tables (effective_year, type, data) VALUES
 ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
 
 -- OT annual limits (hours)
-INSERT INTO tax_tables (effective_year, type, data) VALUES
+INSERT INTO payroll_fiscal_params (effective_year, type, data) VALUES
 (2026, 'ot_annual_limits', '{
   "mpe_hours":       175,
   "others_hours":    150,
@@ -51,7 +52,7 @@ INSERT INTO tax_tables (effective_year, type, data) VALUES
 ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
 
 -- OT IRS withholding (IRS autónomo em OT desde 2025: 50% da taxa base)
-INSERT INTO tax_tables (effective_year, type, data) VALUES
+INSERT INTO payroll_fiscal_params (effective_year, type, data) VALUES
 (2026, 'ot_irs_withholding', '{
   "autonomous_rate_of_base": 0.50,
   "since": "2025-01-01"
@@ -59,7 +60,7 @@ INSERT INTO tax_tables (effective_year, type, data) VALUES
 ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
 
 -- Mileage caps (cap AT 2026: €0,40/km)
-INSERT INTO tax_tables (effective_year, type, data) VALUES
+INSERT INTO payroll_fiscal_params (effective_year, type, data) VALUES
 (2026, 'mileage_caps', '{
   "cents_per_km": 40
 }'::jsonb)
@@ -69,7 +70,7 @@ ON CONFLICT (effective_year, type) DO UPDATE SET data = EXCLUDED.data;
 -- national_general: €65,89/day | national_admin: €72,65/day
 -- foreign_general: €156,36/day | foreign_admin: €175,42/day
 -- breakdown: lunch 25%, dinner 25%, sleep 50%
-INSERT INTO tax_tables (effective_year, type, data) VALUES
+INSERT INTO payroll_fiscal_params (effective_year, type, data) VALUES
 (2026, 'travel_allowance_caps', '{
   "national_general_cents": 6589,
   "national_admin_cents":   7265,

--- a/supabase/migrations/20260507110000_unit12a_policy_columns.sql
+++ b/supabase/migrations/20260507110000_unit12a_policy_columns.sql
@@ -1,0 +1,27 @@
+-- Migration 2: add fiscal columns to existing payroll tables
+
+-- 1. payroll_ot_policies: add ot_hours_ytd (running YTD hour counter)
+ALTER TABLE payroll_ot_policies
+  ADD COLUMN IF NOT EXISTS ot_hours_ytd numeric(6,2) DEFAULT 0;
+
+-- 2. payroll_mileage_policies: add use_tax_table_rate flag
+ALTER TABLE payroll_mileage_policies
+  ADD COLUMN IF NOT EXISTS use_tax_table_rate boolean DEFAULT true;
+
+-- 3. payroll_leaves: add employer_days + affects_subsidy
+ALTER TABLE payroll_leaves
+  ADD COLUMN IF NOT EXISTS employer_days    integer DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS affects_subsidy  boolean DEFAULT false;
+
+-- 4. Fix payroll_leaves CHECK constraint to include 'vacation'
+--    (existing constraint may not include vacation)
+DO $$
+BEGIN
+  -- Drop old constraint if it exists
+  ALTER TABLE payroll_leaves DROP CONSTRAINT IF EXISTS payroll_leaves_leave_type_check;
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+ALTER TABLE payroll_leaves
+  ADD CONSTRAINT payroll_leaves_leave_type_check
+  CHECK (leave_type IN ('sick', 'vacation', 'maternity', 'paternity', 'unpaid', 'other'));

--- a/supabase/migrations/20260507110000_unit12a_policy_columns.sql
+++ b/supabase/migrations/20260507110000_unit12a_policy_columns.sql
@@ -14,14 +14,16 @@ ALTER TABLE payroll_leaves
   ADD COLUMN IF NOT EXISTS affects_subsidy  boolean DEFAULT false;
 
 -- 4. Fix payroll_leaves CHECK constraint to include 'vacation'
---    (existing constraint may not include vacation)
+--    (original values preserved; 'vacation' added)
 DO $$
 BEGIN
-  -- Drop old constraint if it exists
   ALTER TABLE payroll_leaves DROP CONSTRAINT IF EXISTS payroll_leaves_leave_type_check;
-EXCEPTION WHEN OTHERS THEN NULL;
+  ALTER TABLE payroll_leaves
+    ADD CONSTRAINT payroll_leaves_leave_type_check
+    CHECK (leave_type IN (
+      'maternity', 'paternity', 'parental', 'adoption',
+      'sick', 'family_assistance', 'bereavement', 'marriage',
+      'study', 'unpaid', 'vacation', 'other'
+    ));
+EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
-
-ALTER TABLE payroll_leaves
-  ADD CONSTRAINT payroll_leaves_leave_type_check
-  CHECK (leave_type IN ('sick', 'vacation', 'maternity', 'paternity', 'unpaid', 'other'));

--- a/supabase/migrations/20260507110000_unit12a_policy_columns.sql
+++ b/supabase/migrations/20260507110000_unit12a_policy_columns.sql
@@ -1,8 +1,10 @@
 -- Migration 2: add fiscal columns to existing payroll tables
 
 -- 1. payroll_ot_policies: add ot_hours_ytd (running YTD hour counter)
+--    and use_legal_defaults (enables Phase 2 Motor Fiscal calc engine)
 ALTER TABLE payroll_ot_policies
-  ADD COLUMN IF NOT EXISTS ot_hours_ytd numeric(6,2) DEFAULT 0;
+  ADD COLUMN IF NOT EXISTS ot_hours_ytd      numeric(6,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS use_legal_defaults boolean      DEFAULT false;
 
 -- 2. payroll_mileage_policies: add use_tax_table_rate flag
 ALTER TABLE payroll_mileage_policies

--- a/supabase/migrations/20260507120000_unit12a_travel_allowances.sql
+++ b/supabase/migrations/20260507120000_unit12a_travel_allowances.sql
@@ -1,0 +1,33 @@
+-- Migration 3: create payroll_travel_allowances table
+
+CREATE TABLE IF NOT EXISTS payroll_travel_allowances (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id          uuid NOT NULL REFERENCES payroll_contracts(id) ON DELETE CASCADE,
+  type                 text NOT NULL CHECK (type IN (
+                         'deslocacao_nacional',
+                         'deslocacao_estrangeiro',
+                         'deslocacao_viatura_propria',
+                         'alojamento'
+                       )),
+  date_start           date NOT NULL,
+  days                 numeric(5,2),
+  km                   numeric(8,2),
+  role                 text NOT NULL DEFAULT 'general'
+                         CHECK (role IN ('general', 'admin')),
+  declared_cents       integer NOT NULL,
+  taxable_excess_cents integer NOT NULL DEFAULT 0,
+  operation_id         text NOT NULL,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT payroll_travel_allowances_operation_id_key UNIQUE (operation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_travel_allowances_contract_date
+  ON payroll_travel_allowances (contract_id, date_start);
+
+ALTER TABLE payroll_travel_allowances ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "authenticated manage travel_allowances"
+  ON payroll_travel_allowances
+  FOR ALL TO authenticated
+  USING (true)
+  WITH CHECK (true);

--- a/supabase/migrations/20260507120000_unit12a_travel_allowances.sql
+++ b/supabase/migrations/20260507120000_unit12a_travel_allowances.sql
@@ -26,8 +26,24 @@ CREATE INDEX IF NOT EXISTS idx_travel_allowances_contract_date
 
 ALTER TABLE payroll_travel_allowances ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "authenticated manage travel_allowances"
-  ON payroll_travel_allowances
-  FOR ALL TO authenticated
-  USING (true)
-  WITH CHECK (true);
+DO $$
+BEGIN
+  CREATE POLICY "Users can manage own travel allowances"
+    ON payroll_travel_allowances
+    FOR ALL TO authenticated
+    USING (
+      EXISTS (
+        SELECT 1 FROM payroll_contracts pc
+        WHERE pc.id = contract_id
+          AND pc.user_id = auth.uid()
+      )
+    )
+    WITH CHECK (
+      EXISTS (
+        SELECT 1 FROM payroll_contracts pc
+        WHERE pc.id = contract_id
+          AND pc.user_id = auth.uid()
+      )
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary

- **Dual-scale OT** (Lei 13/2023): TypeScript calc engine applies Escala 1 (≤100h YTD, +25%/+37.5%) and Escala 2 (>100h YTD, +50%/+75%) with correct first-hour budget carryover between scales
- **IRS autónomo em OT** (desde 2025): 50% da taxa base IRS retida autonomamente sobre pagamentos de OT
- **Mileage cap** (AT 2026, €0,40/km): per-trip isento/tributável split displayed on mileage page
- **Ajudas de custo** with 2026 PT caps (national/foreign × general/admin): new `TravelAllowancesPage` with real-time exempt/taxable preview
- **Leaves fiscal treatment**: `employer_days` + `affects_subsidy` fields; `calcLeaveImpact` deducts gross for unpaid days
- **`payroll_fiscal_params` table**: JSONB fiscal rate store (renamed from `tax_tables` to avoid Unit 11 schema collision)
- **Two-phase `calculatePayslip`**: Phase 1 = existing RPC; Phase 2 = TypeScript engine (gated by `use_legal_defaults` on OT policy)
- **OT YTD tracker**: progress bars in `WeeklyTimesheetForm` showing E1/E2 threshold and annual limit

## Test Plan

- [ ] Run `npx vitest run src/features/payroll` — all 214 payroll tests pass
- [ ] Run `npx tsc --noEmit` — 0 TypeScript errors
- [ ] Enable `use_legal_defaults = true` on an OT policy and call `calculatePayslip` — Phase 2 engine executes
- [ ] Open `/app/payroll/ajudas-custo` — form renders, preview updates on input, records save/delete
- [ ] Check `/app/payroll/km` — per-trip isento/tributável split visible in summary card
- [ ] Check `/app/payroll/timesheet` — YTD OT tracker panel shows two progress bars
- [ ] Apply migrations in order: `20260507100000`, `20260507110000`, `20260507120000` — no errors

## Migration Notes

Three new migrations (apply in order):
1. `20260507100000_unit12a_tax_tables.sql` — creates `payroll_fiscal_params` + seeds 2026 fiscal rates
2. `20260507110000_unit12a_policy_columns.sql` — adds `ot_hours_ytd`, `use_legal_defaults` to `payroll_ot_policies`; adds `employer_days`, `affects_subsidy` to `payroll_leaves`; fixes leave type CHECK constraint
3. `20260507120000_unit12a_travel_allowances.sql` — creates `payroll_travel_allowances` with RLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)